### PR TITLE
Add QC task

### DIFF
--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -19,6 +19,7 @@ def generate_indicators(
     models,
     scenarios,
     slurm_script,
+    qc_script,
     input_dir,
     output_dir,
 ):

--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -44,6 +44,9 @@ def generate_indicators(
         job_ids = indicator_functions.get_job_ids(ssh, ssh_username)
 
         indicator_functions.wait_for_jobs_completion(ssh, job_ids)
+
+        indicator_functions.qc(ssh, qc_script, output_dir)
+
     finally:
         ssh.close()
 
@@ -57,6 +60,7 @@ if __name__ == "__main__":
     models = "CESM2 GFDL-ESM4 TaiESM1"
     scenarios = "historical ssp126 ssp245 ssp370 ssp585"
     slurm_script = working_directory.joinpath("cmip6-utils/indicators/slurm.py")
+    qc_script = working_directory.joinpath("cmip6-utils/indicators/qc.py")
     input_dir = "/import/beegfs/CMIP6/arctic-cmip6/regrid/"
     output_dir = working_directory.joinpath("indicators/")
 
@@ -72,6 +76,7 @@ if __name__ == "__main__":
             "models": models,
             "scenarios": scenarios,
             "slurm_script": slurm_script,
+            "qc_script": qc_script,
             "input_dir": input_dir,
             "output_dir": output_dir,
         },

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -133,6 +133,11 @@ def qc(ssh, qc_script, output_dir):
         f"python {qc_script} --out_dir '{output_dir}'"
     )
 
+    # Collect output from QC script above and print it
+    lines = stdout.readlines()
+    for line in lines:
+        print(line)
+
     # Wait for the command to finish and get the exit status
     exit_status = stdout.channel.recv_exit_status()
 

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -119,3 +119,20 @@ def wait_for_jobs_completion(ssh, job_ids):
             sleep(10)
 
     print("All indicator jobs completed!")
+
+
+@task
+def qc(ssh, qc_script, output_dir):
+    stdin, stdout, stderr = ssh.exec_command(
+        f"source ~/.bashrc && export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && python {qc_script} --out_dir '{output_dir}'"
+    )
+
+    # Wait for the command to finish and get the exit status
+    exit_status = stdout.channel.recv_exit_status()
+
+    # Check the exit status for errors
+    if exit_status != 0:
+        error_output = stderr.read().decode("utf-8")
+        raise Exception(f"Error running QC script. Error: {error_output}")
+
+    print("QC script run successfully")

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -123,8 +123,14 @@ def wait_for_jobs_completion(ssh, job_ids):
 
 @task
 def qc(ssh, qc_script, output_dir):
+    conda_init_script = (
+        "/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/conda_init.sh"
+    )
+
     stdin, stdout, stderr = ssh.exec_command(
-        f"source ~/.bashrc && export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && python {qc_script} --out_dir '{output_dir}'"
+        f"source {conda_init_script}\n"
+        f"conda activate cmip6-utils\n"
+        f"python {qc_script} --out_dir '{output_dir}'"
     )
 
     # Wait for the command to finish and get the exit status


### PR DESCRIPTION
This PR is associated with the #10[ Add QC PR](https://github.com/ua-snap/cmip6-utils/pull/10) in the `cmip6-utils` repo. This PR adds the QC task to the `indicators/generate_indicators.py` flow, which calls a new `qc()` task from `indicators/indicator_functions.py`. 

Note that the `conda_init_script` variable in that new `qc()` task is hard-coded for now. 

**TO TEST**:

- Start your Prefect server, and run the `indicators/generate_indicators.py` flow from this branch. 
- Follow the testing instructions from the #10[ Add QC PR](https://github.com/ua-snap/cmip6-utils/pull/10) in the `cmip6-utils` repo. 
- The `qc()` task should appear in the Prefect dashboard, and messages from this function should print in the Prefect logs.

