### PR TITLE
Updates parameters provided to the flow and to the Slurm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 `pip install -U prefect paramiko`
 
+## Use the production Prefect server for running real tasks
+
+To set your Terminal window to use the production Prefect server, run the following:
+
+`prefect config set PREFECT_API_URL=https://prefect.earthmaps.io/api`
+
+Now when you trigger a workflow run, you will use the production Prefect server to schedule the task. This also allows for the run to be logged on a shared resource for review by the entire team.
+
 ## Run a local Prefect server to connect your flows
 
 ```
@@ -46,11 +54,3 @@ $ python gipl_ingest.py
 ```
 
 Go to localhost:4200 and click on Deployments, the name of the deployment you want, and hit Run at the top right of the screen. Adjust the parameters to match your environment for your username, your SSH key, etc.
-
-## Use the production Prefect server for running real tasks
-
-To set your Terminal window to use the production Prefect server, run the following:
-
-`prefect config set PREFECT_API_URL=https://prefect.earthmaps.io/api`
-
-Now when you trigger a workflow run, you will use the production Prefect server to schedule the task. This also allows for the run to be logged on a shared resource for review by the entire team.

--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -39,14 +39,14 @@ def generate_indicators(
         indicator_functions.check_for_nfs_mount(ssh, "/import/beegfs")
 
         indicator_functions.create_and_run_slurm_script(
-            ssh, indicators, models, scenarios, slurm_script, input_dir, output_dir
+            ssh, indicators, models, scenarios, working_directory, input_dir
         )
 
         job_ids = indicator_functions.get_job_ids(ssh, ssh_username)
 
         indicator_functions.wait_for_jobs_completion(ssh, job_ids)
 
-        indicator_functions.qc(ssh, qc_script, output_dir)
+        indicator_functions.qc(ssh, working_directory)
 
     finally:
         ssh.close()
@@ -60,10 +60,6 @@ if __name__ == "__main__":
     indicators = "rx1day"
     models = "CESM2 GFDL-ESM4 TaiESM1"
     scenarios = "historical ssp126 ssp245 ssp370 ssp585"
-    slurm_script = working_directory.joinpath("cmip6-utils/indicators/slurm.py")
-    qc_script = working_directory.joinpath("cmip6-utils/indicators/qc.py")
-    input_dir = "/import/beegfs/CMIP6/arctic-cmip6/regrid/"
-    output_dir = working_directory.joinpath("indicators/")
 
     generate_indicators.serve(
         name="generate_indicators",
@@ -76,9 +72,5 @@ if __name__ == "__main__":
             "indicators": indicators,
             "models": models,
             "scenarios": scenarios,
-            "slurm_script": slurm_script,
-            "qc_script": qc_script,
-            "input_dir": input_dir,
-            "output_dir": output_dir,
         },
     )

--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     input_dir = Path("/import/beegfs/CMIP6/arctic-cmip6/regrid/")
 
     generate_indicators.serve(
-        name="generate-indicators-bob",
+        name="generate-indicators",
         tags=["CMIP6 Indicators"],
         parameters={
             "ssh_username": ssh_username,

--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -18,10 +18,7 @@ def generate_indicators(
     indicators,
     models,
     scenarios,
-    slurm_script,
-    qc_script,
     input_dir,
-    output_dir,
 ):
     # Create an SSH client
     ssh = paramiko.SSHClient()
@@ -56,13 +53,14 @@ if __name__ == "__main__":
     ssh_username = "snapdata"
     ssh_private_key_path = "/home/snapdata/.ssh/id_rsa"
     branch_name = "main"
-    working_directory = Path(f"/import/beegfs/CMIP6/{ssh_username}/")
+    working_directory = Path(f"/import/beegfs/CMIP6/snapdata/")
     indicators = "rx1day"
     models = "CESM2 GFDL-ESM4 TaiESM1"
     scenarios = "historical ssp126 ssp245 ssp370 ssp585"
+    input_dir = Path("/import/beegfs/CMIP6/arctic-cmip6/regrid/")
 
     generate_indicators.serve(
-        name="generate_indicators",
+        name="generate-indicators-bob",
         tags=["CMIP6 Indicators"],
         parameters={
             "ssh_username": ssh_username,
@@ -72,5 +70,6 @@ if __name__ == "__main__":
             "indicators": indicators,
             "models": models,
             "scenarios": scenarios,
+            "input_dir": input_dir,
         },
     )

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -25,7 +25,7 @@ def clone_github_repository(ssh, branch, destination_directory):
     if directory_exists:
         # Directory exists, check the current branch
         get_current_branch_command = (
-            f"cd {target_directory} && git branch --show-current"
+            f"cd {target_directory} && git pull && git branch --show-current"
         )
         stdin, stdout, stderr = ssh.exec_command(get_current_branch_command)
         current_branch = stdout.read().decode("utf-8").strip()
@@ -71,10 +71,10 @@ def clone_github_repository(ssh, branch, destination_directory):
 def create_and_run_slurm_script(
     ssh, indicators, models, scenarios, working_directory, input_dir
 ):
-    slurm_script = working_directory.joinpath("cmip6-utils/indicators/slurm.py")
+    slurm_script = f"{working_directory}/cmip6-utils/indicators/slurm.py"
 
     stdin, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --out_dir '{working_directory}'"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --working_dir '{working_directory}'"
     )
 
     # Wait for the command to finish and get the exit status
@@ -127,8 +127,8 @@ def wait_for_jobs_completion(ssh, job_ids):
 def qc(ssh, working_directory):
     conda_init_script = f"{working_directory}/cmip6-utils/indicators/conda_init.sh"
 
-    qc_script = working_directory.joinpath("cmip6-utils/indicators/qc.py")
-    output_dir = working_directory.joinpath("output/")
+    qc_script = f"{working_directory}/cmip6-utils/indicators/qc.py"
+    output_dir = f"{working_directory}/output/"
 
     stdin, stdout, stderr = ssh.exec_command(
         f"source {conda_init_script}\n"

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -69,10 +69,12 @@ def clone_github_repository(ssh, branch, destination_directory):
 
 @task
 def create_and_run_slurm_script(
-    ssh, indicators, models, scenarios, slurm_script, input_dir, output_dir
+    ssh, indicators, models, scenarios, working_directory, input_dir
 ):
+    slurm_script = working_directory.joinpath("cmip6-utils/indicators/slurm.py")
+
     stdin, stdout, stderr = ssh.exec_command(
-        f"source ~/.bashrc && export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --out_dir '{output_dir}'"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --out_dir '{working_directory}'"
     )
 
     # Wait for the command to finish and get the exit status
@@ -91,7 +93,7 @@ def create_and_run_slurm_script(
 @task
 def get_job_ids(ssh, username):
     stdin, stdout, stderr = ssh.exec_command(
-        f"source ~/.bashrc && export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && squeue -u {username}"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && squeue -u {username}"
     )
 
     # Get a list of job IDs for the specified user
@@ -107,7 +109,7 @@ def wait_for_jobs_completion(ssh, job_ids):
         # Check the status of each job in the list
         for job_id in job_ids.copy():
             stdin, stdout, stderr = ssh.exec_command(
-                f"source ~/.bashrc && export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && squeue -h -j {job_id}"
+                f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && squeue -h -j {job_id}"
             )
 
             # If the job is no longer in the queue, remove it from the list
@@ -122,10 +124,11 @@ def wait_for_jobs_completion(ssh, job_ids):
 
 
 @task
-def qc(ssh, qc_script, output_dir):
-    conda_init_script = (
-        "/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/conda_init.sh"
-    )
+def qc(ssh, working_directory):
+    conda_init_script = f"{working_directory}/cmip6-utils/indicators/conda_init.sh"
+
+    qc_script = working_directory.joinpath("cmip6-utils/indicators/qc.py")
+    output_dir = working_directory.joinpath("output/")
 
     stdin, stdout, stderr = ssh.exec_command(
         f"source {conda_init_script}\n"

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -99,6 +99,7 @@ def get_job_ids(ssh, username):
     # Get a list of job IDs for the specified user
     job_ids = [line.split()[0] for line in stdout.readlines()[1:]]  # Skip header
 
+    # Prints the list of job IDs to the log for debugging purposes
     print(job_ids)
     return job_ids
 


### PR DESCRIPTION
This PR changes the parameters that need to be set when running the indicator workflow along with what it is passing to the Slurm generation script on the remote host. You should be able to set the working directory to a read-writable-executable directory that will then be used to generate the outputs for all of the stages of the indicator processing on Chinook.

To run this flow, you must point the Github repository branch name to **fix_variable_inputs** which is in a PR at: https://github.com/ua-snap/cmip6-utils/pull/15