### PR TITLE
Checks for Conda environment and installs Miniconda and the cmip6-utils Conda environment if not found

### DIFF
--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -35,6 +35,10 @@ def generate_indicators(
 
         indicator_functions.check_for_nfs_mount(ssh, "/import/beegfs")
 
+        indicator_functions.install_conda_environment(
+            ssh, "cmip6-utils", f"{working_directory}/cmip6-utils/environment.yml"
+        )
+
         indicator_functions.create_and_run_slurm_script(
             ssh, indicators, models, scenarios, working_directory, input_dir
         )

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -96,10 +96,6 @@ def clone_github_repository(ssh, branch, destination_directory):
             )
 
 
-from prefect import task
-import paramiko
-
-
 @task
 def install_conda_environment(ssh, conda_env_name, conda_env_file):
     """


### PR DESCRIPTION
This PR adds a new function to the flow for creating indicators that installs the required Python environment if one doesn't exist. 

To test this, I would recommend running the indicators function where you set the username to be: snapdata

You will change your SSH private key to be: /Users/<your_username>/.ssh/id_rsa like /Users/kmredilla 

Go onto Chinook04 as the snapdata user and make sure to run the command: rm -rf ~snapdata/* and rm -rf /import/beegfs/CMIP6/snapdata/* before attempting to run this. You can SSH in as the snapdata user by running this from your local computer: ssh snapdata@chinook04.rcs.alaska.edu

Let me know if you run into any issues with the Miniconda environment getting installed and running through the indicator generation process.