### PR TITLE
Add {input_dir} parameter to qc()

### DIFF
--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -43,7 +43,7 @@ def generate_indicators(
 
         indicator_functions.wait_for_jobs_completion(ssh, job_ids)
 
-        indicator_functions.qc(ssh, working_directory)
+        indicator_functions.qc(ssh, working_directory, input_dir)
 
     finally:
         ssh.close()

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -125,7 +125,7 @@ def wait_for_jobs_completion(ssh, job_ids):
 
 
 @task
-def qc(ssh, working_directory):
+def qc(ssh, working_directory, input_dir):
     conda_init_script = f"{working_directory}/cmip6-utils/indicators/conda_init.sh"
 
     qc_script = f"{working_directory}/cmip6-utils/indicators/qc.py"
@@ -134,7 +134,7 @@ def qc(ssh, working_directory):
     stdin, stdout, stderr = ssh.exec_command(
         f"source {conda_init_script}\n"
         f"conda activate cmip6-utils\n"
-        f"python {qc_script} --out_dir '{output_dir}'"
+        f"python {qc_script} --out_dir '{output_dir}' --in_dir '{input_dir}'"
     )
 
     # Collect output from QC script above and print it


### PR DESCRIPTION
As the title implies, this small PR just adds the existing {input_dir} parameter to the `indicators/indicator_functions.qc()` function. This allows for checking the nodata cells in the computed indicators against the input files used to create them. This is a companion to [PR #17](https://github.com/ua-snap/cmip6-utils/pull/17) in the cmip6-utils repo.