### PR TITLE
Add visual QC

### DIFF
--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -49,7 +49,7 @@ def generate_indicators(
 
         indicator_functions.qc(ssh, working_directory, input_dir)
 
-        indicator_functions.visual_qc_nb(ssh, working_directory, indicators, models, scenarios)
+        indicator_functions.visual_qc_nb(ssh, working_directory, input_dir)
 
     finally:
         ssh.close()

--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -49,6 +49,8 @@ def generate_indicators(
 
         indicator_functions.qc(ssh, working_directory, input_dir)
 
+        indicator_functions.visual_qc_nb(ssh, working_directory, indicators, models, scenarios)
+
     finally:
         ssh.close()
 

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -293,14 +293,16 @@ def visual_qc_nb(ssh, working_directory, input_directory):
     """
 
     conda_init_script = f"{working_directory}/cmip6-utils/indicators/conda_init.sh"
-
+    repo_indicators_dir = f"{working_directory}/cmip6-utils/indicators"
     visual_qc_nb = f"{working_directory}/cmip6-utils/indicators/visual_qc.ipynb"
     output_nb = f"{working_directory}/output/qc/visual_qc_out.ipynb"
 
     stdin, stdout, stderr = ssh.exec_command(
         f"source {conda_init_script}\n"
         f"conda activate cmip6-utils\n"
-        f"papermill {visual_qc_nb} {output_nb} -r working_directory '{working_directory}' -r input_directory '{input_directory}'"
+        f"cd {repo_indicators_dir}\n"
+        f"papermill {visual_qc_nb} {output_nb} -r working_directory '{working_directory}' -r input_directory '{input_directory}'\n"
+        f"jupyter nbconvert --to html {output_nb}"
     )
 
     # Collect output from QC script above and print it

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -283,7 +283,7 @@ def qc(ssh, working_directory, input_dir):
 
 
 @task
-def visual_qc_nb(ssh, working_directory, indicators, models, scenarios):
+def visual_qc_nb(ssh, working_directory, input_directory):
     """
     Task to run the visual quality control (QC) notebook to check the output of the indicator calculations.
 
@@ -300,7 +300,7 @@ def visual_qc_nb(ssh, working_directory, indicators, models, scenarios):
     stdin, stdout, stderr = ssh.exec_command(
         f"source {conda_init_script}\n"
         f"conda activate cmip6-utils\n"
-        f"papermill {visual_qc_nb} {output_nb} -r indicators '{indicators}' -r models '{models}' -r scenarios '{scenarios}'"
+        f"papermill {visual_qc_nb} {output_nb} -r working_directory '{working_directory}' -r input_directory '{input_directory}'"
     )
 
     # Collect output from QC script above and print it

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -289,7 +289,8 @@ def visual_qc_nb(ssh, working_directory, input_directory):
 
     Parameters:
     - ssh: Paramiko SSHClient object
-    - working_directory: Directory to where all of the processing takes place
+    - working_directory: Directory where all of the processing takes place
+    - input_directory: Directory containing source input data collection
     """
 
     conda_init_script = f"{working_directory}/cmip6-utils/indicators/conda_init.sh"


### PR DESCRIPTION
This PR adds the `indicator_functions.visual_qc_nb()` task/function to the prefect flow which uses `papermill` to execute a visual QC notebook and save the result in both `.ipynb` and `.html` formats. This is a companion [PR #21](https://github.com/ua-snap/cmip6-utils/pull/21) in the [visual-qc branch](https://github.com/ua-snap/cmip6-utils/tree/visual-qc) of the cmip6-utils repo, which contains a new QC notebook, an auxillary shapefile, and an updated `environment.yml`.

Both `papermill` and `geopandas` packages were added to the `cmip6-utils` conda environment in order to execute the QC notebook. You should therefore update the `cmip6-utils` env before testing this PR by using the new `environment.yml` mentioned above. You might even need to delete the original env first and rebuild from scratch.

**To test:**
- update your `cmip6-utils` env using the new `environment.yml` mentioned above
- confirm you are on the `add_viz_qc` branch of the prefect repo and start the prefect server
- run `python generate_indicators.py` as usual
- create a new flow run using the `visual-qc` branch of the cmip6-utils repo
- confirm the new `visual_qc_nb()` task runs successfully
- check the `output/qc/...` directory for `visual_qc_out.ipynb` and `visual_qc_out.html`
- copy these outputs to your local machine somehow. I used `scp` from my local like so:
```
scp jdpaul3@chinook04.alaska.edu:/import/beegfs/CMIP6/jdpaul3/scratch/output/qc/visual_qc_out.html /Users/joshpaul/Downloads
```
- review the outputs