### PR TITLE
Regridding via Prefect

### DIFF
--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -33,9 +33,9 @@ def regrid_cmip6(
     target_grid_fp = f"{cmip6_directory}/ScenarioMIP/NCAR/CESM2/ssp370/r11i1p1f1/Amon/tas/gn/v20200528/tas_Amon_CESM2_ssp370_r11i1p1f1_gn_206501-210012.nc"
 
     # make these dirs if they don't exist
-    Path(regrid_dir).mkdir(exist_ok=True)
-    Path(regrid_batch_dir).mkdir(exist_ok=True)
-    Path(slurm_dir).mkdir(exist_ok=True)
+    Path(regrid_dir).mkdir(exist_ok=True, parents=True)
+    Path(regrid_batch_dir).mkdir(exist_ok=True, parents=True)
+    Path(slurm_dir).mkdir(exist_ok=True, parents=True)
 
     # Create an SSH client
     ssh = paramiko.SSHClient()

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -18,6 +18,7 @@ def regrid_cmip6(
     scratch_directory,
     slurm_email,
     no_clobber,
+    generate_batch_files,
 ):
     
     # build additional parameters from prefect inputs
@@ -50,11 +51,13 @@ def regrid_cmip6(
 
         regridding_functions.install_conda_environment(ssh, "cmip6-utils", f"{scratch_directory}/cmip6-utils/environment.yml")
 
-        regridding_functions.run_generate_batch_files(ssh, conda_init_script, generate_batch_files_script, run_generate_batch_files_script, cmip6_directory, regrid_batch_dir, slurm_email)
+        if generate_batch_files == True:
+            
+            regridding_functions.run_generate_batch_files(ssh, conda_init_script, generate_batch_files_script, run_generate_batch_files_script, cmip6_directory, regrid_batch_dir, slurm_email)
 
-        job_ids = regridding_functions.get_job_ids(ssh, ssh_username)
+            job_ids = regridding_functions.get_job_ids(ssh, ssh_username)
 
-        regridding_functions.wait_for_jobs_completion(ssh, job_ids)
+            regridding_functions.wait_for_jobs_completion(ssh, job_ids)
 
         regridding_functions.create_and_run_slurm_scripts(ssh, 
                                                           slurm_script, 
@@ -88,6 +91,7 @@ if __name__ == "__main__":
     scratch_directory = Path(f"/center1/CMIP6/snapdata/")
     slurm_email = "uaf-snap-sys-team@alaska.edu"
     no_clobber = False
+    generate_batch_files = True
 
     regrid_cmip6.serve(
         name="regrid-cmip6",
@@ -100,5 +104,6 @@ if __name__ == "__main__":
             "scratch_directory": scratch_directory,
             "slurm_email": slurm_email,
             "no_clobber": no_clobber,
+            "generate_batch_files": generate_batch_files,
         },
     )

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -1,0 +1,81 @@
+from prefect import flow
+import paramiko
+from pathlib import Path
+
+import regridding_functions
+
+# Define your SSH parameters
+ssh_host = "chinook04.rcs.alaska.edu"
+ssh_port = 22
+
+
+@flow(log_prints=True)
+def regrid_cmip6(
+    ssh_username,
+    ssh_private_key_path,
+    branch_name,
+    working_directory,
+    #indicators,
+    #models,
+    #scenarios,
+    #input_dir,
+):
+    # Create an SSH client
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    try:
+        # Load the private key for key-based authentication
+        private_key = paramiko.RSAKey(filename=ssh_private_key_path)
+
+        # Connect to the SSH server using key-based authentication
+        ssh.connect(ssh_host, ssh_port, ssh_username, pkey=private_key)
+
+        #regridding_functions.clone_github_repository(ssh, branch_name, working_directory)
+
+        #regridding_functions.check_for_nfs_mount(ssh, "/import/beegfs")
+
+        # regridding_functions.install_conda_environment(
+        #     ssh, "cmip6-utils", f"{working_directory}/cmip6-utils/environment.yml"
+        # )
+
+        # regridding_functions.create_and_run_slurm_script(
+        #     ssh, indicators, models, scenarios, working_directory, input_dir
+        # )
+
+        #job_ids = regridding_functions.get_job_ids(ssh, ssh_username)
+
+        #regridding_functions.wait_for_jobs_completion(ssh, job_ids)
+
+        #regridding_functions.qc(ssh, working_directory, input_dir)
+
+        #regridding_functions.visual_qc_nb(ssh, working_directory, input_dir)
+
+    finally:
+        ssh.close()
+
+
+if __name__ == "__main__":
+    ssh_username = "snapdata"
+    ssh_private_key_path = "/home/snapdata/.ssh/id_rsa"
+    branch_name = "main"
+    working_directory = Path(f"/import/beegfs/CMIP6/snapdata/")
+    #indicators = "rx1day"
+    #models = "CESM2 GFDL-ESM4 TaiESM1"
+    #scenarios = "historical ssp126 ssp245 ssp370 ssp585"
+    #input_dir = Path("/import/beegfs/CMIP6/arctic-cmip6/regrid/")
+
+    regrid_cmip6.serve(
+        name="regrid-cmip6",
+        tags=["CMIP6 Regridding"],
+        parameters={
+            "ssh_username": ssh_username,
+            "ssh_private_key_path": ssh_private_key_path,
+            "branch_name": branch_name,
+            "working_directory": working_directory,
+            #"indicators": indicators,
+            #"models": models,
+            #"scenarios": scenarios,
+            #"input_dir": input_dir,
+        },
+    )

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -27,9 +27,10 @@ def regrid_cmip6(
     slurm_script = f"{scratch_directory}/cmip6-utils/regridding/slurm.py"
     generate_batch_files_script = f"{scratch_directory}/cmip6-utils/regridding/generate_batch_files.py"
     run_generate_batch_files_script = f"{scratch_directory}/cmip6-utils/regridding/run_generate_batch_files.py"
-    regrid_dir = f"{scratch_directory}/regrid"
-    regrid_batch_dir = f"{scratch_directory}/regrid_batch"
-    slurm_dir = f"{scratch_directory}/slurm"
+    output_directory = f"{scratch_directory}/cmip6_regridding"
+    regrid_dir = f"{output_directory}/regrid"
+    regrid_batch_dir = f"{output_directory}/regrid_batch"
+    slurm_dir = f"{output_directory}/slurm"
 
     # target regridding file - all files will be regridded to the grid in this file
     target_grid_fp = f"{cmip6_directory}/ScenarioMIP/NCAR/CESM2/ssp370/r11i1p1f1/Amon/tas/gn/v20200528/tas_Amon_CESM2_ssp370_r11i1p1f1_gn_206501-210012.nc"

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -22,10 +22,10 @@ def regrid_cmip6(
     
     # build additional parameters from prefect inputs
     conda_init_script = f"{scratch_directory}/cmip6-utils/regridding/conda_init.sh"
-    regrid_script = f"{scratch_directory}/regridding/regrid.py"
-    slurm_script = f"{scratch_directory}/regridding/slurm.py"
-    generate_batch_files_script = f"{scratch_directory}/regridding/generate_batch_files.py"
-    run_generate_batch_files_script = f"{scratch_directory}/regridding/run_generate_batch_files.py"
+    regrid_script = f"{scratch_directory}/cmip6-utils/regridding/regrid.py"
+    slurm_script = f"{scratch_directory}/cmip6-utils/regridding/slurm.py"
+    generate_batch_files_script = f"{scratch_directory}/cmip6-utils/regridding/generate_batch_files.py"
+    run_generate_batch_files_script = f"{scratch_directory}/cmip6-utils/regridding/run_generate_batch_files.py"
     regrid_dir = f"{scratch_directory}/regrid"
     regrid_batch_dir = f"{scratch_directory}/regrid_batch"
     slurm_dir = f"{scratch_directory}/slurm"

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -32,11 +32,6 @@ def regrid_cmip6(
     # target regridding file - all files will be regridded to the grid in this file
     target_grid_fp = f"{cmip6_directory}/ScenarioMIP/NCAR/CESM2/ssp370/r11i1p1f1/Amon/tas/gn/v20200528/tas_Amon_CESM2_ssp370_r11i1p1f1_gn_206501-210012.nc"
 
-    # # make these dirs if they don't exist
-    # Path(regrid_dir).mkdir(exist_ok=True, parents=True)
-    # Path(regrid_batch_dir).mkdir(exist_ok=True, parents=True)
-    # Path(slurm_dir).mkdir(exist_ok=True, parents=True)
-
     # Create an SSH client
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -47,11 +42,6 @@ def regrid_cmip6(
 
         # Connect to the SSH server using key-based authentication
         ssh.connect(ssh_host, ssh_port, ssh_username, pkey=private_key)
-
-        # make these dirs if they don't exist
-        Path(regrid_dir).mkdir(exist_ok=True, parents=True)
-        Path(regrid_batch_dir).mkdir(exist_ok=True, parents=True)
-        Path(slurm_dir).mkdir(exist_ok=True, parents=True)
 
         regridding_functions.clone_github_repository(ssh, branch_name, scratch_directory)
 

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -22,15 +22,15 @@ def regrid_cmip6(
     
     # build additional parameters from prefect inputs
     conda_init_script = f"{scratch_directory}/cmip6-utils/regridding/conda_init.sh"
-    regrid_script = scratch_directory.joinpath("regridding/regrid.py")
-    slurm_script = scratch_directory.joinpath("regridding/slurm.py")
-    generate_batch_files_script = scratch_directory.joinpath("regridding/generate_batch_files.py")
-    regrid_dir = scratch_directory.joinpath("regrid")
-    regrid_batch_dir = scratch_directory.joinpath("regrid_batch")
-    slurm_dir = scratch_directory.joinpath("slurm")
+    regrid_script = f"{scratch_directory}/regridding/regrid.py"
+    slurm_script = f"{scratch_directory}/regridding/slurm.py"
+    generate_batch_files_script = f"{scratch_directory}/regridding/generate_batch_files.py"
+    regrid_dir = f"{scratch_directory}/regrid"
+    regrid_batch_dir = f"{scratch_directory}/regrid_batch"
+    slurm_dir = f"{scratch_directory}/slurm"
 
     # target regridding file - all files will be regridded to the grid in this file
-    target_grid_fp = cmip6_directory.joinpath("ScenarioMIP/NCAR/CESM2/ssp370/r11i1p1f1/Amon/tas/gn/v20200528/tas_Amon_CESM2_ssp370_r11i1p1f1_gn_206501-210012.nc")
+    target_grid_fp = f"{cmip6_directory}/ScenarioMIP/NCAR/CESM2/ssp370/r11i1p1f1/Amon/tas/gn/v20200528/tas_Amon_CESM2_ssp370_r11i1p1f1_gn_206501-210012.nc"
 
     # make these dirs if they don't exist
     regrid_dir.mkdir(exist_ok=True)

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -14,12 +14,29 @@ def regrid_cmip6(
     ssh_username,
     ssh_private_key_path,
     branch_name,
-    working_directory,
-    #indicators,
-    #models,
-    #scenarios,
-    #input_dir,
+    cmip6_directory,
+    project_directory,
+    scratch_directory
 ):
+    
+    # build additional parameters from prefect inputs
+    conda_init_script = f"{project_directory}/cmip6-utils/regridding/conda_init.sh"
+    regrid_script = project_directory.joinpath("regridding/regrid.py")
+    manifest_filepath = project_directory.joinpath("transfers/llnl_manifest.csv")
+    regrid_dir = scratch_directory.joinpath("regrid")
+    regrid_batch_dir = scratch_directory.joinpath("regrid_batch")
+    slurm_dir = scratch_directory.joinpath("slurm")
+    transfers_config = project_directory.joinpath("transfers/config.py")
+
+    # target regridding file - all files will be regridded to the grid in this file
+    target_grid_fp = cmip6_directory.joinpath("ScenarioMIP/NCAR/CESM2/ssp370/r11i1p1f1/Amon/tas/gn/v20200528/tas_Amon_CESM2_ssp370_r11i1p1f1_gn_206501-210012.nc")
+
+    # make these dirs if they don't exist
+    regrid_dir.mkdir(exist_ok=True)
+    regrid_batch_dir.mkdir(exist_ok=True)
+    slurm_dir.mkdir(exist_ok=True)
+
+
     # Create an SSH client
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -56,14 +73,14 @@ def regrid_cmip6(
 
 
 if __name__ == "__main__":
+    # prefect parameter inputs 
     ssh_username = "snapdata"
     ssh_private_key_path = "/home/snapdata/.ssh/id_rsa"
     branch_name = "main"
-    working_directory = Path(f"/import/beegfs/CMIP6/snapdata/")
-    #indicators = "rx1day"
-    #models = "CESM2 GFDL-ESM4 TaiESM1"
-    #scenarios = "historical ssp126 ssp245 ssp370 ssp585"
-    #input_dir = Path("/import/beegfs/CMIP6/arctic-cmip6/regrid/")
+    cmip6_directory = Path("/beegfs/CMIP6/arctic-cmip6/CMIP6")
+    project_directory = Path(f"/import/beegfs/CMIP6/snapdata/") #repo directory
+    scratch_directory = Path(f"/center1/CMIP6/snapdata/") #directory to where all of the processing takes place
+    slurm_email = "uaf-snap-sys-team@alaska.edu"
 
     regrid_cmip6.serve(
         name="regrid-cmip6",
@@ -72,10 +89,9 @@ if __name__ == "__main__":
             "ssh_username": ssh_username,
             "ssh_private_key_path": ssh_private_key_path,
             "branch_name": branch_name,
-            "working_directory": working_directory,
-            #"indicators": indicators,
-            #"models": models,
-            #"scenarios": scenarios,
-            #"input_dir": input_dir,
+            "cmip6_directory": cmip6_directory,
+            "project_directory": project_directory,
+            "scratch_directory": scratch_directory,
+            "slurm_email": slurm_email,
         },
     )

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -33,9 +33,9 @@ def regrid_cmip6(
     target_grid_fp = f"{cmip6_directory}/ScenarioMIP/NCAR/CESM2/ssp370/r11i1p1f1/Amon/tas/gn/v20200528/tas_Amon_CESM2_ssp370_r11i1p1f1_gn_206501-210012.nc"
 
     # make these dirs if they don't exist
-    regrid_dir.mkdir(exist_ok=True)
-    regrid_batch_dir.mkdir(exist_ok=True)
-    slurm_dir.mkdir(exist_ok=True)
+    Path(regrid_dir).mkdir(exist_ok=True)
+    Path(regrid_batch_dir).mkdir(exist_ok=True)
+    Path(slurm_dir).mkdir(exist_ok=True)
 
     # Create an SSH client
     ssh = paramiko.SSHClient()

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -15,17 +15,16 @@ def regrid_cmip6(
     ssh_private_key_path,
     branch_name,
     cmip6_directory,
-    project_directory,
     scratch_directory,
     slurm_email,
     no_clobber,
 ):
     
     # build additional parameters from prefect inputs
-    conda_init_script = f"{project_directory}/cmip6-utils/regridding/conda_init.sh"
-    regrid_script = project_directory.joinpath("regridding/regrid.py")
-    slurm_script = project_directory.joinpath("regridding/slurm.py")
-    generate_batch_files_script = project_directory.joinpath("regridding/generate_batch_files.py")
+    conda_init_script = f"{scratch_directory}/cmip6-utils/regridding/conda_init.sh"
+    regrid_script = scratch_directory.joinpath("regridding/regrid.py")
+    slurm_script = scratch_directory.joinpath("regridding/slurm.py")
+    generate_batch_files_script = scratch_directory.joinpath("regridding/generate_batch_files.py")
     regrid_dir = scratch_directory.joinpath("regrid")
     regrid_batch_dir = scratch_directory.joinpath("regrid_batch")
     slurm_dir = scratch_directory.joinpath("slurm")
@@ -49,11 +48,11 @@ def regrid_cmip6(
         # Connect to the SSH server using key-based authentication
         ssh.connect(ssh_host, ssh_port, ssh_username, pkey=private_key)
 
-        regridding_functions.clone_github_repository(ssh, branch_name, project_directory)
+        regridding_functions.clone_github_repository(ssh, branch_name, scratch_directory)
 
         regridding_functions.check_for_nfs_mount(ssh, "/import/beegfs")
 
-        regridding_functions.install_conda_environment(ssh, "cmip6-utils", f"{project_directory}/cmip6-utils/environment.yml")
+        regridding_functions.install_conda_environment(ssh, "cmip6-utils", f"{scratch_directory}/cmip6-utils/environment.yml")
 
         regridding_functions.generate_batch_files(ssh, conda_init_script, generate_batch_files_script, cmip6_directory, regrid_batch_dir, slurm_email)
 
@@ -90,7 +89,6 @@ if __name__ == "__main__":
     ssh_private_key_path = "/home/snapdata/.ssh/id_rsa"
     branch_name = "main"
     cmip6_directory = Path("/beegfs/CMIP6/arctic-cmip6/CMIP6")
-    project_directory = Path(f"/import/beegfs/CMIP6/snapdata/") 
     scratch_directory = Path(f"/center1/CMIP6/snapdata/")
     slurm_email = "uaf-snap-sys-team@alaska.edu"
     no_clobber = False
@@ -103,7 +101,6 @@ if __name__ == "__main__":
             "ssh_private_key_path": ssh_private_key_path,
             "branch_name": branch_name,
             "cmip6_directory": cmip6_directory,
-            "project_directory": project_directory,
             "scratch_directory": scratch_directory,
             "slurm_email": slurm_email,
             "no_clobber": no_clobber,

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -74,6 +74,8 @@ def regrid_cmip6(
 
         regridding_functions.wait_for_jobs_completion(ssh, job_ids)
 
+        #regridding_functions.tests(ssh, working_directory, input_dir)
+
         #regridding_functions.qc(ssh, working_directory, input_dir)
 
         #regridding_functions.visual_qc_nb(ssh, working_directory, input_dir)

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -32,10 +32,10 @@ def regrid_cmip6(
     # target regridding file - all files will be regridded to the grid in this file
     target_grid_fp = f"{cmip6_directory}/ScenarioMIP/NCAR/CESM2/ssp370/r11i1p1f1/Amon/tas/gn/v20200528/tas_Amon_CESM2_ssp370_r11i1p1f1_gn_206501-210012.nc"
 
-    # make these dirs if they don't exist
-    Path(regrid_dir).mkdir(exist_ok=True, parents=True)
-    Path(regrid_batch_dir).mkdir(exist_ok=True, parents=True)
-    Path(slurm_dir).mkdir(exist_ok=True, parents=True)
+    # # make these dirs if they don't exist
+    # Path(regrid_dir).mkdir(exist_ok=True, parents=True)
+    # Path(regrid_batch_dir).mkdir(exist_ok=True, parents=True)
+    # Path(slurm_dir).mkdir(exist_ok=True, parents=True)
 
     # Create an SSH client
     ssh = paramiko.SSHClient()
@@ -47,6 +47,11 @@ def regrid_cmip6(
 
         # Connect to the SSH server using key-based authentication
         ssh.connect(ssh_host, ssh_port, ssh_username, pkey=private_key)
+
+        # make these dirs if they don't exist
+        Path(regrid_dir).mkdir(exist_ok=True, parents=True)
+        Path(regrid_batch_dir).mkdir(exist_ok=True, parents=True)
+        Path(slurm_dir).mkdir(exist_ok=True, parents=True)
 
         regridding_functions.clone_github_repository(ssh, branch_name, scratch_directory)
 

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -25,6 +25,7 @@ def regrid_cmip6(
     regrid_script = f"{scratch_directory}/regridding/regrid.py"
     slurm_script = f"{scratch_directory}/regridding/slurm.py"
     generate_batch_files_script = f"{scratch_directory}/regridding/generate_batch_files.py"
+    run_generate_batch_files_script = f"{scratch_directory}/regridding/run_generate_batch_files.py"
     regrid_dir = f"{scratch_directory}/regrid"
     regrid_batch_dir = f"{scratch_directory}/regrid_batch"
     slurm_dir = f"{scratch_directory}/slurm"
@@ -49,7 +50,7 @@ def regrid_cmip6(
 
         regridding_functions.install_conda_environment(ssh, "cmip6-utils", f"{scratch_directory}/cmip6-utils/environment.yml")
 
-        regridding_functions.generate_batch_files(ssh, conda_init_script, generate_batch_files_script, cmip6_directory, regrid_batch_dir, slurm_email)
+        regridding_functions.run_generate_batch_files(ssh, conda_init_script, generate_batch_files_script, run_generate_batch_files_script, cmip6_directory, regrid_batch_dir, slurm_email)
 
         job_ids = regridding_functions.get_job_ids(ssh, ssh_username)
 

--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -161,22 +161,35 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
 
 
 @task
-def create_and_run_slurm_script(
-    ssh, working_directory, input_dir
-):
+def create_and_run_slurm_scripts(ssh, 
+                                slurm_script, 
+                                slurm_dir,
+                                regrid_dir,
+                                regrid_batch_dir,
+                                slurm_email,
+                                conda_init_script,
+                                regrid_script,
+                                target_grid_fp,
+                                no_clobber
+                                ):
     """
-    Task to create and run a Slurm script to regrid batches of CMIP6 data.
+    Task to create and submit Slurm scripts to regrid batches of CMIP6 data.
 
     Parameters:
     - ssh: Paramiko SSHClient object
-    - working_directory: Directory to where all of the processing takes place
-    - input_dir: Directory containing the input data for the indicators
+    - slurm_script: Directory to regridding slurm.py script
+    - slurm_dir:
+    - regrid_dir: 
+    - regrid_batch_dir:
+    - slurm_email:
+    - conda_init_script:
+    - regrid_script:
+    - target_grid_fp:
+    - no_clobber: 
     """
 
-    slurm_script = f"{working_directory}/cmip6-utils/regridding/slurm.py"
-
-    stdin, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --working_dir '{working_directory}'"
+    stdin_, stdout, stderr = ssh.exec_command(
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --slurm_email '{slurm_email}' --conda_init_script '{conda_init_script}' --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}' --no_clobber '{no_clobber}'"
     )
 
     # Wait for the command to finish and get the exit status

--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -275,81 +275,38 @@ def wait_for_jobs_completion(ssh, job_ids):
     print("Jobs completed!")
 
 #TODO: implement regridding/tests.slurm from here
-
 #TODO: create QC functions for regridding pipeline and call them from here
     
+
 # @task
-# def qc(ssh, working_directory, input_dir):
+# def tests(ssh, working_directory, input_dir):
 #     """
-#     Task to run the quality control (QC) script to check the output of the indicator calculations.
+#     Task to run the tests to check the output of the regridding pipeline.
 
 #     Parameters:
 #     - ssh: Paramiko SSHClient object
 #     - working_directory: Directory to where all of the processing takes place
 #     """
 
-#     conda_init_script = f"{working_directory}/cmip6-utils/indicators/conda_init.sh"
+    
+# @task
+# def qc(ssh, working_directory, input_dir):
+#     """
+#     Task to run the quality control (QC) script to check the output of the regridding pipeline.
 
-#     qc_script = f"{working_directory}/cmip6-utils/indicators/qc.py"
-#     output_dir = f"{working_directory}/output/"
-
-#     stdin, stdout, stderr = ssh.exec_command(
-#         f"source {conda_init_script}\n"
-#         f"conda activate cmip6-utils\n"
-#         f"python {qc_script} --out_dir '{output_dir}' --in_dir '{input_dir}'"
-#     )
-
-#     # Collect output from QC script above and print it
-#     lines = stdout.readlines()
-#     for line in lines:
-#         print(line)
-
-#     # Wait for the command to finish and get the exit status
-#     exit_status = stdout.channel.recv_exit_status()
-
-#     # Check the exit status for errors
-#     if exit_status != 0:
-#         error_output = stderr.read().decode("utf-8")
-#         raise Exception(f"Error running QC script. Error: {error_output}")
-
-#     print("QC script run successfully")
+#     Parameters:
+#     - ssh: Paramiko SSHClient object
+#     - working_directory: Directory to where all of the processing takes place
+#     """
 
 
 # @task
 # def visual_qc_nb(ssh, working_directory, input_directory):
 #     """
-#     Task to run the visual quality control (QC) notebook to check the output of the indicator calculations.
+#     Task to run the visual quality control (QC) notebook to check the output of the regriddig pipeline.
 
 #     Parameters:
 #     - ssh: Paramiko SSHClient object
 #     - working_directory: Directory where all of the processing takes place
 #     - input_directory: Directory containing source input data collection
 #     """
-
-#     conda_init_script = f"{working_directory}/cmip6-utils/indicators/conda_init.sh"
-#     repo_indicators_dir = f"{working_directory}/cmip6-utils/indicators"
-#     visual_qc_nb = f"{working_directory}/cmip6-utils/indicators/visual_qc.ipynb"
-#     output_nb = f"{working_directory}/output/qc/visual_qc_out.ipynb"
-
-#     stdin, stdout, stderr = ssh.exec_command(
-#         f"source {conda_init_script}\n"
-#         f"conda activate cmip6-utils\n"
-#         f"cd {repo_indicators_dir}\n"
-#         f"papermill {visual_qc_nb} {output_nb} -r working_directory '{working_directory}' -r input_directory '{input_directory}'\n"
-#         f"jupyter nbconvert --to html {output_nb}"
-#     )
-
-#     # Collect output from QC script above and print it
-#     lines = stdout.readlines()
-#     for line in lines:
-#         print(line)
-
-#     # Wait for the command to finish and get the exit status
-#     exit_status = stdout.channel.recv_exit_status()
-
-#     # Check the exit status for errors
-#     if exit_status != 0:
-#         error_output = stderr.read().decode("utf-8")
-#         raise Exception(f"Error running Visual QC script. Error: {error_output}")
-
-#     print(f"Visual QC notebook created successfully. See {output_nb} for results.")

--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -1,0 +1,322 @@
+from time import sleep
+from prefect import task
+import paramiko
+
+
+@task
+def check_for_nfs_mount(ssh, nfs_directory="/import/beegfs"):
+    """
+    Task to check if an NFS directory is mounted on the remote server via SSH.
+
+    Parameters:
+    - ssh: Paramiko SSHClient object
+    - nfs_directory: Path to the NFS directory to check for
+    """
+
+    stdin, stdout, stderr = ssh.exec_command(f"df -h | grep {nfs_directory}")
+
+    nfs_mounted = bool(stdout.read())
+
+    if not nfs_mounted:
+        raise Exception(f"NFS directory '{nfs_directory}' is not mounted")
+
+
+@task
+def clone_github_repository(ssh, branch, destination_directory):
+    """
+    Task to clone a GitHub repository via SSH and switch to a specific branch if it exists.
+
+    Parameters:
+    - ssh: Paramiko SSHClient object
+    - branch: Name of the branch to clone and switch to
+    - destination_directory: Directory to clone the repository into
+    """
+
+    target_directory = f"{destination_directory}/cmip6-utils"
+    stdin, stdout, stderr = ssh.exec_command(
+        f"if [ -d '{target_directory}' ]; then echo 'true'; else echo 'false'; fi"
+    )
+
+    directory_exists = stdout.read().decode("utf-8").strip() == "true"
+
+    if directory_exists:
+        try:
+            # Directory exists, check the current branch
+            get_current_branch_command = (
+                f"cd {target_directory} && git pull && git branch --show-current"
+            )
+            stdin, stdout, stderr = ssh.exec_command(get_current_branch_command)
+            current_branch = stdout.read().decode("utf-8").strip()
+        except:
+            # If the current branch cannot be determined, assume it's the wrong branch
+            set_branch_to_main = f"cd {target_directory} && git checkout main"
+            stdin, stdout, stderr = ssh.exec_command(set_branch_to_main)
+
+            # Get the current branch again# Directory exists, check the current branch
+            get_current_branch_command = (
+                f"cd {target_directory} && git pull && git branch --show-current"
+            )
+            stdin, stdout, stderr = ssh.exec_command(get_current_branch_command)
+            current_branch = stdout.read().decode("utf-8").strip()
+
+        if current_branch != branch:
+            print(f"Change repository branch to branch {branch}...")
+            # If the current branch is different from the desired branch, switch to the correct branch
+            switch_branch_command = f"cd {target_directory} && git checkout {branch}"
+            stdin, stdout, stderr = ssh.exec_command(switch_branch_command)
+
+        print(f"Pulling the GitHub repository on branch {branch}...")
+
+        # Run the Git pull command to pull the repository
+        git_pull_command = f"cd {target_directory} && git pull origin {branch}"
+        stdin, stdout, stderr = ssh.exec_command(git_pull_command)
+
+        # Wait for the Git command to finish and get the exit status
+        exit_status = stdout.channel.recv_exit_status()
+
+        # Check the exit status for errors
+        if exit_status != 0:
+            raise Exception(
+                f"Error cloning the GitHub repository. Exit status: {exit_status}"
+            )
+    else:
+        print(f"Cloning the GitHub repository on branch {branch}...")
+        # Run the Git clone command to clone the repository
+        git_command = f"cd {destination_directory} && git clone -b {branch} https://github.com/ua-snap/cmip6-utils.git"
+        stdin, stdout, stderr = ssh.exec_command(git_command)
+
+        # Wait for the Git command to finish and get the exit status
+        exit_status = stdout.channel.recv_exit_status()
+
+        # Check the exit status for errors
+        if exit_status != 0:
+            error_output = stderr.read().decode("utf-8")
+            raise Exception(
+                f"Error cloning the GitHub repository. Error: {error_output}"
+            )
+
+
+@task
+def install_conda_environment(ssh, conda_env_name, conda_env_file):
+    """
+    Task to check for a Python Conda environment and install it from an environment file
+    if it doesn't exist on the user's account via SSH. It also checks for Miniconda installation
+    and installs Miniconda if it doesn't exist.
+
+    Parameters:
+    - ssh: Paramiko SSHClient object
+    - conda_env_name: Name of the Conda environment to create/install
+    - conda_env_file: Path to the Conda environment file (.yml) to use for installation
+    """
+
+    # Check if the Miniconda directory exists in the user's home directory
+    stdin, stdout, stderr = ssh.exec_command(
+        "test -d $HOME/miniconda3 && echo 1 || echo 0"
+    )
+
+    miniconda_found = int(stdout.read())
+    miniconda_installed = bool(miniconda_found)
+
+    if not miniconda_installed:
+        print("Miniconda directory not found. Installing Miniconda...")
+        # Download and install Miniconda
+        install_miniconda_cmd = "wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && bash miniconda.sh -b -p $HOME/miniconda3"
+        stdin, stdout, stderr = ssh.exec_command(install_miniconda_cmd)
+
+        # Wait for the command to finish and get the exit status
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status != 0:
+            error_output = stderr.read().decode("utf-8")
+            raise Exception(f"Error installing Miniconda. Error: {error_output}")
+
+        print("Miniconda installed successfully")
+
+    # Check if the Conda environment already exists
+    stdin, stdout, stderr = ssh.exec_command(
+        f"source $HOME/miniconda3/bin/activate && $HOME/miniconda3/bin/conda env list | grep {conda_env_name}"
+    )
+
+    conda_env_exists = bool(stdout.read())
+
+    if not conda_env_exists:
+        print(f"Conda environment '{conda_env_name}' does not exist. Installing...")
+
+        # Install the Conda environment from the environment file
+        install_cmd = f"source $HOME/miniconda3/bin/activate && $HOME/miniconda3/bin/conda env create -n {conda_env_name} -f {conda_env_file}"
+        stdin, stdout, stderr = ssh.exec_command(install_cmd)
+
+        # Wait for the command to finish and get the exit status
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status == 0:
+            print(f"Conda environment '{conda_env_name}' installed successfully")
+        else:
+            error_output = stderr.read().decode("utf-8")
+            raise Exception(
+                f"Error installing Conda environment '{conda_env_name}'. Error: {error_output}"
+            )
+    else:
+        print(f"Conda environment '{conda_env_name}' already exists.")
+
+
+# @task
+# def create_and_run_slurm_script(
+#     ssh, indicators, models, scenarios, working_directory, input_dir
+# ):
+#     """
+#     Task to create and run a Slurm script to run the indicator calculation scripts.
+
+#     Parameters:
+#     - ssh: Paramiko SSHClient object
+#     - indicators: Space-separated list of indicators to calculate
+#     - models: Space-separated list of models to calculate indicators for
+#     - scenarios: Space-separated list of scenarios to calculate indicators for
+#     - working_directory: Directory to where all of the processing takes place
+#     - input_dir: Directory containing the input data for the indicators
+#     """
+
+#     slurm_script = f"{working_directory}/cmip6-utils/indicators/slurm.py"
+
+#     stdin, stdout, stderr = ssh.exec_command(
+#         f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --working_dir '{working_directory}'"
+#     )
+
+#     # Wait for the command to finish and get the exit status
+#     exit_status = stdout.channel.recv_exit_status()
+
+#     # Check the exit status for errors
+#     if exit_status != 0:
+#         error_output = stderr.read().decode("utf-8")
+#         raise Exception(
+#             f"Error creating or running Slurm scripts. Error: {error_output}"
+#         )
+
+#     print("Slurm scripts created and run successfully")
+
+
+# @task
+# def get_job_ids(ssh, username):
+#     """
+#     Task to get a list of job IDs for a specified user from the Slurm queue via SSH.
+
+#     Parameters:
+#     - ssh: Paramiko SSHClient object
+#     - username: Username to get job IDs for
+#     """
+
+#     stdin, stdout, stderr = ssh.exec_command(
+#         f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && squeue -u {username}"
+#     )
+
+#     # Get a list of job IDs for the specified user
+#     job_ids = [line.split()[0] for line in stdout.readlines()[1:]]  # Skip header
+
+#     # Prints the list of job IDs to the log for debugging purposes
+#     print(job_ids)
+#     return job_ids
+
+
+# @task
+# def wait_for_jobs_completion(ssh, job_ids):
+#     """
+#     Task to wait for a list of Slurm jobs to complete in the queue via SSH.
+
+#     Parameters:
+#     - ssh: Paramiko SSHClient object
+#     - job_ids: List of job IDs to wait for
+#     """
+
+#     while job_ids:
+#         # Check the status of each job in the list
+#         for job_id in job_ids.copy():
+#             stdin, stdout, stderr = ssh.exec_command(
+#                 f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin && squeue -h -j {job_id}"
+#             )
+
+#             # If the job is no longer in the queue, remove it from the list
+#             if not stdout.read():
+#                 job_ids.remove(job_id)
+
+#         if job_ids:
+#             # Sleep for a while before checking again
+#             sleep(10)
+
+#     print("All indicator jobs completed!")
+
+
+# @task
+# def qc(ssh, working_directory, input_dir):
+#     """
+#     Task to run the quality control (QC) script to check the output of the indicator calculations.
+
+#     Parameters:
+#     - ssh: Paramiko SSHClient object
+#     - working_directory: Directory to where all of the processing takes place
+#     """
+
+#     conda_init_script = f"{working_directory}/cmip6-utils/indicators/conda_init.sh"
+
+#     qc_script = f"{working_directory}/cmip6-utils/indicators/qc.py"
+#     output_dir = f"{working_directory}/output/"
+
+#     stdin, stdout, stderr = ssh.exec_command(
+#         f"source {conda_init_script}\n"
+#         f"conda activate cmip6-utils\n"
+#         f"python {qc_script} --out_dir '{output_dir}' --in_dir '{input_dir}'"
+#     )
+
+#     # Collect output from QC script above and print it
+#     lines = stdout.readlines()
+#     for line in lines:
+#         print(line)
+
+#     # Wait for the command to finish and get the exit status
+#     exit_status = stdout.channel.recv_exit_status()
+
+#     # Check the exit status for errors
+#     if exit_status != 0:
+#         error_output = stderr.read().decode("utf-8")
+#         raise Exception(f"Error running QC script. Error: {error_output}")
+
+#     print("QC script run successfully")
+
+
+# @task
+# def visual_qc_nb(ssh, working_directory, input_directory):
+#     """
+#     Task to run the visual quality control (QC) notebook to check the output of the indicator calculations.
+
+#     Parameters:
+#     - ssh: Paramiko SSHClient object
+#     - working_directory: Directory where all of the processing takes place
+#     - input_directory: Directory containing source input data collection
+#     """
+
+#     conda_init_script = f"{working_directory}/cmip6-utils/indicators/conda_init.sh"
+#     repo_indicators_dir = f"{working_directory}/cmip6-utils/indicators"
+#     visual_qc_nb = f"{working_directory}/cmip6-utils/indicators/visual_qc.ipynb"
+#     output_nb = f"{working_directory}/output/qc/visual_qc_out.ipynb"
+
+#     stdin, stdout, stderr = ssh.exec_command(
+#         f"source {conda_init_script}\n"
+#         f"conda activate cmip6-utils\n"
+#         f"cd {repo_indicators_dir}\n"
+#         f"papermill {visual_qc_nb} {output_nb} -r working_directory '{working_directory}' -r input_directory '{input_directory}'\n"
+#         f"jupyter nbconvert --to html {output_nb}"
+#     )
+
+#     # Collect output from QC script above and print it
+#     lines = stdout.readlines()
+#     for line in lines:
+#         print(line)
+
+#     # Wait for the command to finish and get the exit status
+#     exit_status = stdout.channel.recv_exit_status()
+
+#     # Check the exit status for errors
+#     if exit_status != 0:
+#         error_output = stderr.read().decode("utf-8")
+#         raise Exception(f"Error running Visual QC script. Error: {error_output}")
+
+#     print(f"Visual QC notebook created successfully. See {output_nb} for results.")

--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -160,39 +160,36 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
         print(f"Conda environment '{conda_env_name}' already exists.")
 
 
-# @task
-# def create_and_run_slurm_script(
-#     ssh, indicators, models, scenarios, working_directory, input_dir
-# ):
-#     """
-#     Task to create and run a Slurm script to run the indicator calculation scripts.
+@task
+def create_and_run_slurm_script(
+    ssh, working_directory, input_dir
+):
+    """
+    Task to create and run a Slurm script to regrid batches of CMIP6 data.
 
-#     Parameters:
-#     - ssh: Paramiko SSHClient object
-#     - indicators: Space-separated list of indicators to calculate
-#     - models: Space-separated list of models to calculate indicators for
-#     - scenarios: Space-separated list of scenarios to calculate indicators for
-#     - working_directory: Directory to where all of the processing takes place
-#     - input_dir: Directory containing the input data for the indicators
-#     """
+    Parameters:
+    - ssh: Paramiko SSHClient object
+    - working_directory: Directory to where all of the processing takes place
+    - input_dir: Directory containing the input data for the indicators
+    """
 
-#     slurm_script = f"{working_directory}/cmip6-utils/indicators/slurm.py"
+    slurm_script = f"{working_directory}/cmip6-utils/regridding/slurm.py"
 
-#     stdin, stdout, stderr = ssh.exec_command(
-#         f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --working_dir '{working_directory}'"
-#     )
+    stdin, stdout, stderr = ssh.exec_command(
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --working_dir '{working_directory}'"
+    )
 
-#     # Wait for the command to finish and get the exit status
-#     exit_status = stdout.channel.recv_exit_status()
+    # Wait for the command to finish and get the exit status
+    exit_status = stdout.channel.recv_exit_status()
 
-#     # Check the exit status for errors
-#     if exit_status != 0:
-#         error_output = stderr.read().decode("utf-8")
-#         raise Exception(
-#             f"Error creating or running Slurm scripts. Error: {error_output}"
-#         )
+    # Check the exit status for errors
+    if exit_status != 0:
+        error_output = stderr.read().decode("utf-8")
+        raise Exception(
+            f"Error creating or running Slurm scripts. Error: {error_output}"
+        )
 
-#     print("Slurm scripts created and run successfully")
+    print("Slurm scripts created and run successfully")
 
 
 # @task


### PR DESCRIPTION
This PR closes #16 and is a companion to [PR #40](https://github.com/ua-snap/cmip6-utils/pull/40) for the `regrid_prefect` [branch of the cmip6-utils repo](https://github.com/ua-snap/cmip6-utils/tree/regrid_prefect).

Using the indicators work as a template, this branch adds a Prefect flow that orchestrates the regridding pipeline. A bunch of code is reused from the indicators work (mostly the setup tasks and the tasks to monitor slurm jobs). 

Along with the typical parameters for user info and scratch directory, the user has an option here to skip generating batch files (useful to save 30 minutes in the flow run as we keep developing the regridding pipeline on the same set of input files) and to prevent overwriting previously regridded files (via the `no_clobber` parameter). _(Note that the `no_clobber` option is not actually implemented yet, but the parameter is included here and has been passed thru to the appropriate functions!)_

Some changes were made to the regridding pipeline in order to accomplish this, and those changes are in the [regrid_prefect branch](https://github.com/ua-snap/cmip6-utils/tree/regrid_prefect) of the `cmip6-utils` repo. Those changes are breifly described here:

- Instead of using `config.py` and environmental variables, the various directories needed for the pipeline are just constructed from the `scratch_directory` parameter in the `regrid_cmip6.regrid_cmip6()` function. (This is similar to what we did in the inidicators flow.) As a result, more arguments have to be passed to `slurm.py` and `regrid.py` for all the directories since they are not readily available from `config.py`.
- A new `run_generate_batch_files.py` script was needed to pass parameters to `generate_batch_files.py`, create the sbatch head and slurm file, and submit a the slurm job for that process. 
-  The step of submitting the slurm jobs was moved out of the `regrid_cmip6.ipynb` notebook and into the main block of `slurm.py`

**TO TEST:**

- On the `regridding` branch of this repo, start the server and run ```python regrid_cmip6.py```
- Start a new flow run using the following parameters (substituting your ssh/user info, email, and your own scratch dir):
```
{
  "ssh_username": "jdpaul3",
  "ssh_private_key_path": "/Users/joshpaul/.ssh/id_rsa",
  "branch_name": "regrid_prefect",
  "cmip6_directory": "/beegfs/CMIP6/arctic-cmip6/CMIP6",
  "scratch_directory": "/center1/CMIP6/jdpaul3/regrid_prefect",
  "slurm_email": "jdpaul3@alaska.edu",
  "no_clobber": true,
  "generate_batch_files": true
}
```
- Wait until you are sure that the `run_generate_batch_files()` task has completed, and the `create_and_run_slurm_scripts()` task has started. At this point you can cancel the flow run and also cancel the slurm jobs from your terminal using ```scancel -u your_chinook_username```
- Check out the batch files that were created (there should be 260 of them).
- Delete all but a random handful of the batch files. I ran the following in the `{scratch_directory}/regrid_batch` directory:
```
mkdir tmp
mv -t ./tmp batch_EC-Earth3-Veg_ssp245_gr0_13.txt batch_KACE-1-0-G_historical_gr1_0.txt batch_CNRM-CM6-1-HR_ssp126_gr0_0.txt batch_TaiESM1_ssp585_gr1_0.txt 
rm *.txt
mv tmp/* .
rm -rf tmp
```
- Now start a brand new prefect flow, but change the `generate_batch_files` parameter input to "false". Run the flow, and you should see that the `run_generate_batch_files()` task has been skipped and the `create_and_run_slurm_scripts()` task should start immediately after the setup tasks are done. 
- Wait for the process to complete and verify that regridded files exist in the `{scratch_directory}/regrid` directory