### PR TITLE
pass no_clobber as action argument

### DIFF
--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -208,9 +208,12 @@ def create_and_run_slurm_scripts(ssh,
     - no_clobber: Do not overwrite regidded files if they exist
     """
 
-    stdin_, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --slurm_email '{slurm_email}' --conda_init_script '{conda_init_script}' --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}' --no_clobber '{no_clobber}'"
-    )
+    cmd = f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --slurm_email '{slurm_email}' --conda_init_script '{conda_init_script}' --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}'"
+
+    if no_clobber:
+        cmd += " --no_clobber"
+
+    stdin_, stdout, stderr = ssh.exec_command(cmd)
 
     # Wait for the command to finish and get the exit status
     exit_status = stdout.channel.recv_exit_status()


### PR DESCRIPTION
This is a small PR that just transitions the `{no_clobber}` parameter from a user input string to a `store_false` type argument in the slurm script. (This was how the original argument was set up, but was changed in a previous version of the `no_clobber` branch.) 

There is a corresponding PR in the [cmip6-utils `no_clobber` repo](https://github.com/ua-snap/cmip6-utils/tree/no_clobber).

**TO TEST**:

Follow the instructions in the cmip6-utils [`no_clobber` PR](https://github.com/ua-snap/cmip6-utils/pull/45) and confirm that the argument still functions as expected.