### PR TITLE
Include MultiPolygons in wildfire polygon shapefile

### DIFF
--- a/wildfire_map/fire_layers/get_current_fire_layers.py
+++ b/wildfire_map/fire_layers/get_current_fire_layers.py
@@ -278,7 +278,7 @@ def convert_geojson_to_shapefile(geojson_features, out_shapefile, feature_type="
 
         if geom_type == "Point":
             layer = point_layer
-        elif geom_type == "Polygon":
+        elif geom_type in ["Polygon", "MultiPolygon"]:
             layer = polygon_layer
         else:
             continue  # Skip unsupported geometries


### PR DESCRIPTION
This PR simply includes features of type `MultiPolygon` in the `fire_polygons.shp` file generated by `get_current_fire_layers.py`, not just features of type `Polygon`.

To test this, I did not actually run this in Prefect. Instead, I made a modified/trimmed down version of `get_current_fire_layers.py` that I ran locally and verified that it produced the expected fire shapefiles. I uploaded the polygon shapefile to the `playground` workspace on GeoServer as `playground:fire_polygons`.

If you run a local instance of the Alaska Wildfires app and replace `alaska_wildfires:fire_polygons` with `playground:fire_polygons`, you can see that the large McDonald wildfire now shows up as expected.