### PR TITLE
Split out frequencies, models, and scenarios in regridding pipeline

### DIFF
--- a/regridding/README.md
+++ b/regridding/README.md
@@ -1,0 +1,47 @@
+# CMIP6 regridding pipeline
+
+The `regrid_cmip6` flow is used for generating SNAP's production CMIP6 dataset. This is simply standardizing all raw CMIP6 outputs mirrored from the [Earth System Grid Federation](https://esgf.llnl.gov/) onto a common spatial grid, including file structure (how data are named and grouped into files) and calendar (365-day, with no leap years). We use the same grid used by NCAR-CESM2, TaiESM1, and NorESM2-MM, as this was the most common grid among the models in SNAP's 12-model ensemble. This grid is a "finite-volume grid with 0.9x1.25 degree lat/lon resolution" (note, the actual latitude resolution in the files is ~0.94°).
+
+Below is a list of all possible variables that could be included in the a run of the regridding pipeline, for reference:
+
+| CMIP6 variable ID | Full variable name |
+|-|-|
+| clt | cloud area fraction |
+|evspsbl | evaporation including sublimation and transpiration|
+|hfls | surface upward latent heat flux|
+|hfss | surface upward sensible heat flux|
+|hus | specific humidity|
+|huss | near surface specific humidity|
+|mrro | total runoff|
+|mrsol | moisture in upper portion of soil column|
+|mrsos | total water content of soil layer|
+|pr | precipitation|
+|prsn | snowfall flux|
+|ps | surface air pressure|
+|psl | sea level pressure|
+|rlds | surface downwelling longwave flux in air|
+|rls | surface net downward longwave flux|
+|rsds | surface downwelling shortwave flux_in_air|
+|rss | surface net downward shortwave flux|
+|siconc | sea ice concentration|
+|sithick | sea ice thickness|
+|snd | surface snow thickness|
+|snw | surface snow amount|
+|ta | air temperature|
+|tas | near surface air temperature|
+|tasmax | maximum near surface air temperature|
+|tasmin | minimum near surface air temperature|
+|tos | sea surface temperature|
+|ts | surface temperature|
+|tsl | soil temperature|
+|ua | eastward wind|
+|uas | near surface eastward wind|
+|va | northward wind|
+|vas | near surface northwawrd wind|
+|sfcWind | surface wind speed|
+|sfcWindmax | maximum surface wind speed|
+|sftlf | percentage of the grid cell occupied by land including lakes|
+|sftof | sea area percentage|
+|orog | surface altitude|
+|zg | geopotential height at 500hPa|
+

--- a/regridding/luts.py
+++ b/regridding/luts.py
@@ -59,3 +59,24 @@ sea_vars = [
 ]
 
 global_vars = [i for i in all_vars if i not in land_vars + sea_vars]
+
+# the only two frequencies allowed for regridding are monthly and daily
+all_freqs = ["mon", "day"]
+
+all_models = [
+    "CESM2",
+    "CNRM-CM6-1-HR",
+    "EC-Earth3-Veg",
+    "GFDL-ESM4",
+    "HadGEM3-GC31-LL",
+    "HadGEM3-GC31-MM",
+    "KACE-1-0-G",
+    "MIROC6",
+    "MPI-ESM1-2-HR",
+    "MPI-ESM1-2-LR",
+    "MRI-ESM2-0",
+    "NorESM2-MM",
+    "TaiESM1",
+]
+
+all_scenarios = ["historical", "ssp126", "ssp245", "ssp370", "ssp585"]

--- a/regridding/luts.py
+++ b/regridding/luts.py
@@ -4,44 +4,44 @@
 # these were copied from the transfers/config.py in the cmip6-utils repo and include the WRF variables
 
 all_vars = [
-    "clt",
-    "evspsbl",
-    "hfls",
-    "hfss",
-    "hus",
-    "huss",
-    "mrro",
-    "mrsol",
-    "mrsos",
-    "orog",
-    "pr",
-    "prsn",
-    "ps",
-    "psl",
-    "rlds",
-    "rls",
-    "rsds",
-    "rss",
-    "sfcWind",
-    "sfcWindmax",
-    "sftlf",
-    "sftof",
-    "siconc",
-    "sithick",
-    "snd",
-    "snw",
-    "ta",
-    "tas",
-    "tasmax",
-    "tasmin",
-    "tos",
-    "ts",
-    "tsl",
-    "ua",
-    "uas",
-    "va",
-    "vas",
-    "zg",
+    "clt",  # cloud area fraction
+    "evspsbl",  # evaporation including sublimation and transpiration
+    "hfls",  # surface upward latent heat flux
+    "hfss",  # surface upward sensible heat flux
+    "hus",  # specific humidity
+    "huss",  # near surface specific humidity
+    "mrro",  # total runoff
+    "mrsol",  # moisture in upper portion of soil column
+    "mrsos",  # total water content of soil layer
+    "orog",  # surface altitude
+    "pr",  # precipitation
+    "prsn",  # snowfall flux
+    "ps",  # surface air pressure
+    "psl",  # sea level pressure
+    "rlds",  # surface downwelling longwave flux in air
+    "rls",  # surface net downward longwave flux
+    "rsds",  # surface downwelling shortwave flux_in_air
+    "rss",  # surface net downward shortwave flux
+    "sfcWind",  # surface wind speed
+    "sfcWindmax",  # maximum surface wind speed
+    "sftlf",  # percentage of the grid cell occupied by land including lakes
+    "sftof",  # sea area percentage
+    "siconc",  # sea ice concentration
+    "sithick",  # sea ice thickness
+    "snd",  # surface snow thickness
+    "snw",  # surface snow amount
+    "ta",  # air temperature
+    "tas",  # near surface air temperature
+    "tasmax",  # maximum near surface air temperature
+    "tasmin",  # minimum near surface air temperature
+    "tos",  # sea surface temperature
+    "ts",  # surface temperature
+    "tsl",  # soil temperature
+    "ua",  # eastward wind
+    "uas",  # near surface eastward wind
+    "va",  # northward wind
+    "vas",  # near surface northwawrd wind
+    "zg",  # geopotential height at 500hPa
 ]
 
 land_vars = [

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -22,6 +22,7 @@ def regrid_cmip6(
     freqs,
     models,
     scenarios,
+    conda_env_name,
 ):
     vars = regridding_functions.validate_vars(vars)
     freqs = regridding_functions.validate_freqs(freqs)
@@ -68,13 +69,14 @@ def regrid_cmip6(
         regridding_functions.check_for_nfs_mount(ssh, "/import/beegfs")
 
         regridding_functions.install_conda_environment(
-            ssh, "cmip6-utils", f"{scratch_directory}/cmip6-utils/environment.yml"
+            ssh, conda_env_name, f"{scratch_directory}/cmip6-utils/environment.yml"
         )
 
         if generate_batch_files == True:
             regridding_functions.run_generate_batch_files(
                 ssh,
                 conda_init_script,
+                conda_env_name,
                 generate_batch_files_script,
                 run_generate_batch_files_script,
                 cmip6_directory,
@@ -96,6 +98,7 @@ def regrid_cmip6(
             regrid_dir,
             regrid_batch_dir,
             conda_init_script,
+            conda_env_name,
             regrid_script,
             target_grid_fp,
             no_clobber,
@@ -115,6 +118,7 @@ def regrid_cmip6(
             cmip6_directory,
             repo_regridding_directory,
             conda_init_script,
+            conda_env_name,
             run_qc_script,
             qc_script,
             visual_qc_notebook,
@@ -145,6 +149,7 @@ if __name__ == "__main__":
     freqs = "all"
     models = "all"
     scenarios = "all"
+    conda_env_name = "cmip6-utils"
 
     regrid_cmip6.serve(
         name="regrid-cmip6",
@@ -161,5 +166,6 @@ if __name__ == "__main__":
             "freqs": freqs,
             "models": models,
             "scenarios": scenarios,
+            "conda_env_name": conda_env_name,
         },
     )

--- a/regridding/regrid_cmip6.py
+++ b/regridding/regrid_cmip6.py
@@ -16,12 +16,17 @@ def regrid_cmip6(
     branch_name,
     cmip6_directory,
     scratch_directory,
-    slurm_email,
     no_clobber,
     generate_batch_files,
     vars,
+    freqs,
+    models,
+    scenarios,
 ):
     vars = regridding_functions.validate_vars(vars)
+    freqs = regridding_functions.validate_freqs(freqs)
+    models = regridding_functions.validate_models(models)
+    scenarios = regridding_functions.validate_scenarios(scenarios)
 
     # build additional parameters from prefect inputs
     repo_regridding_directory = f"{scratch_directory}/cmip6-utils/regridding"
@@ -74,8 +79,10 @@ def regrid_cmip6(
                 run_generate_batch_files_script,
                 cmip6_directory,
                 regrid_batch_dir,
-                slurm_email,
                 vars,
+                freqs,
+                models,
+                scenarios,
             )
 
             job_ids = regridding_functions.get_job_ids(ssh, ssh_username)
@@ -88,11 +95,14 @@ def regrid_cmip6(
             slurm_dir,
             regrid_dir,
             regrid_batch_dir,
-            slurm_email,
             conda_init_script,
             regrid_script,
             target_grid_fp,
             no_clobber,
+            vars,
+            freqs,
+            models,
+            scenarios,
         )
 
         job_ids = regridding_functions.get_job_ids(ssh, ssh_username)
@@ -109,7 +119,9 @@ def regrid_cmip6(
             qc_script,
             visual_qc_notebook,
             vars,
-            slurm_email,
+            freqs,
+            models,
+            scenarios,
         )
 
         job_ids = regridding_functions.get_job_ids(ssh, ssh_username)
@@ -127,10 +139,12 @@ if __name__ == "__main__":
     branch_name = "main"
     cmip6_directory = Path("/beegfs/CMIP6/arctic-cmip6/CMIP6")
     scratch_directory = Path(f"/center1/CMIP6/snapdata/")
-    slurm_email = "uaf-snap-sys-team@alaska.edu"
     no_clobber = False
     generate_batch_files = True
     vars = "all"
+    freqs = "all"
+    models = "all"
+    scenarios = "all"
 
     regrid_cmip6.serve(
         name="regrid-cmip6",
@@ -141,9 +155,11 @@ if __name__ == "__main__":
             "branch_name": branch_name,
             "cmip6_directory": cmip6_directory,
             "scratch_directory": scratch_directory,
-            "slurm_email": slurm_email,
             "no_clobber": no_clobber,
             "generate_batch_files": generate_batch_files,
             "vars": vars,
+            "freqs": freqs,
+            "models": models,
+            "scenarios": scenarios,
         },
     )

--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -14,7 +14,7 @@ def check_for_nfs_mount(ssh, nfs_directory="/import/beegfs"):
     - nfs_directory: Path to the NFS directory to check for
     """
 
-    stdin, stdout, stderr = ssh.exec_command(f"df -h | grep {nfs_directory}")
+    stdin_, stdout, stderr_ = ssh.exec_command(f"df -h | grep {nfs_directory}")
 
     nfs_mounted = bool(stdout.read())
 
@@ -34,7 +34,7 @@ def clone_github_repository(ssh, branch, destination_directory):
     """
 
     target_directory = f"{destination_directory}/cmip6-utils"
-    stdin, stdout, stderr = ssh.exec_command(
+    stdin_, stdout, stderr = ssh.exec_command(
         f"if [ -d '{target_directory}' ]; then echo 'true'; else echo 'false'; fi"
     )
 
@@ -46,31 +46,31 @@ def clone_github_repository(ssh, branch, destination_directory):
             get_current_branch_command = (
                 f"cd {target_directory} && git pull && git branch --show-current"
             )
-            stdin, stdout, stderr = ssh.exec_command(get_current_branch_command)
+            stdin_, stdout, stderr = ssh.exec_command(get_current_branch_command)
             current_branch = stdout.read().decode("utf-8").strip()
         except:
             # If the current branch cannot be determined, assume it's the wrong branch
             set_branch_to_main = f"cd {target_directory} && git checkout main"
-            stdin, stdout, stderr = ssh.exec_command(set_branch_to_main)
+            stdin_, stdout, stderr = ssh.exec_command(set_branch_to_main)
 
             # Get the current branch again# Directory exists, check the current branch
             get_current_branch_command = (
                 f"cd {target_directory} && git pull && git branch --show-current"
             )
-            stdin, stdout, stderr = ssh.exec_command(get_current_branch_command)
+            stdin_, stdout, stderr = ssh.exec_command(get_current_branch_command)
             current_branch = stdout.read().decode("utf-8").strip()
 
         if current_branch != branch:
             print(f"Change repository branch to branch {branch}...")
             # If the current branch is different from the desired branch, switch to the correct branch
             switch_branch_command = f"cd {target_directory} && git checkout {branch}"
-            stdin, stdout, stderr = ssh.exec_command(switch_branch_command)
+            stdin_, stdout, stderr = ssh.exec_command(switch_branch_command)
 
         print(f"Pulling the GitHub repository on branch {branch}...")
 
         # Run the Git pull command to pull the repository
         git_pull_command = f"cd {target_directory} && git pull origin {branch}"
-        stdin, stdout, stderr = ssh.exec_command(git_pull_command)
+        stdin_, stdout, stderr = ssh.exec_command(git_pull_command)
 
         # Wait for the Git command to finish and get the exit status
         exit_status = stdout.channel.recv_exit_status()
@@ -84,7 +84,7 @@ def clone_github_repository(ssh, branch, destination_directory):
         print(f"Cloning the GitHub repository on branch {branch}...")
         # Run the Git clone command to clone the repository
         git_command = f"cd {destination_directory} && git clone -b {branch} https://github.com/ua-snap/cmip6-utils.git"
-        stdin, stdout, stderr = ssh.exec_command(git_command)
+        stdin_, stdout, stderr = ssh.exec_command(git_command)
 
         # Wait for the Git command to finish and get the exit status
         exit_status = stdout.channel.recv_exit_status()
@@ -111,7 +111,7 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
     """
 
     # Check if the Miniconda directory exists in the user's home directory
-    stdin, stdout, stderr = ssh.exec_command(
+    stdin_, stdout, stderr = ssh.exec_command(
         "test -d $HOME/miniconda3 && echo 1 || echo 0"
     )
 
@@ -122,7 +122,7 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
         print("Miniconda directory not found. Installing Miniconda...")
         # Download and install Miniconda
         install_miniconda_cmd = "wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && bash miniconda.sh -b -p $HOME/miniconda3"
-        stdin, stdout, stderr = ssh.exec_command(install_miniconda_cmd)
+        stdin_, stdout, stderr = ssh.exec_command(install_miniconda_cmd)
 
         # Wait for the command to finish and get the exit status
         exit_status = stdout.channel.recv_exit_status()
@@ -134,7 +134,7 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
         print("Miniconda installed successfully")
 
     # Check if the Conda environment already exists
-    stdin, stdout, stderr = ssh.exec_command(
+    stdin_, stdout, stderr = ssh.exec_command(
         f"source $HOME/miniconda3/bin/activate && $HOME/miniconda3/bin/conda env list | grep {conda_env_name}"
     )
 
@@ -145,7 +145,7 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
 
         # Install the Conda environment from the environment file
         install_cmd = f"source $HOME/miniconda3/bin/activate && $HOME/miniconda3/bin/conda env create -n {conda_env_name} -f {conda_env_file}"
-        stdin, stdout, stderr = ssh.exec_command(install_cmd)
+        stdin_, stdout, stderr = ssh.exec_command(install_cmd)
 
         # Wait for the command to finish and get the exit status
         exit_status = stdout.channel.recv_exit_status()

--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -171,9 +171,11 @@ def run_generate_batch_files(
     regrid_batch_dir,
     vars,
     freqs,
+    models,
+    scenarios,
 ):
     stdin_, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_generate_batch_files_script} --generate_batch_files_script '{generate_batch_files_script}' --conda_init_script '{conda_init_script}' --cmip6_directory '{cmip6_directory}' --regrid_batch_dir '{regrid_batch_dir}' --vars '{vars}' --freqs '{freqs}'"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_generate_batch_files_script} --generate_batch_files_script '{generate_batch_files_script}' --conda_init_script '{conda_init_script}' --cmip6_directory '{cmip6_directory}' --regrid_batch_dir '{regrid_batch_dir}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
     )
 
     # Wait for the command to finish and get the exit status
@@ -200,6 +202,8 @@ def create_and_run_slurm_scripts(
     no_clobber,
     vars,
     freqs,
+    models,
+    scenarios,
 ):
     """
     Task to create and submit Slurm scripts to regrid batches of CMIP6 data.
@@ -216,7 +220,7 @@ def create_and_run_slurm_scripts(
     - no_clobber: Do not overwrite regidded files if they exist
     """
 
-    cmd = f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --conda_init_script '{conda_init_script}' --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}' --vars '{vars}' --freqs '{freqs}'"
+    cmd = f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --conda_init_script '{conda_init_script}' --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
 
     if no_clobber:
         cmd += " --no_clobber"

--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -165,6 +165,7 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
 def run_generate_batch_files(
     ssh,
     conda_init_script,
+    conda_env_name,
     generate_batch_files_script,
     run_generate_batch_files_script,
     cmip6_directory,
@@ -174,8 +175,23 @@ def run_generate_batch_files(
     models,
     scenarios,
 ):
+    """
+    Task to create and submit slurm script to generate the batch files for the regridding.
+
+    Parameters:
+    - ssh: Paramiko SSHClient object
+    - slurm_script: Directory to regridding slurm.py script
+    - slurm_dir: Directory to save slurm sbatch files
+    - regrid_dir: Path to directory where regridded files are written
+    - regrid_batch_dir: Directory of batch files
+    - conda_init_script: Script to initialize conda during slurm jobs
+    - conda_env_name: Name of the Conda environment to activate
+    - regrid_script: Location of regrid.py script in the repo
+    - target_grid_fp: Path to file used as the regridding target
+    - no_clobber: Do not overwrite regidded files if they exist
+    """
     stdin_, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_generate_batch_files_script} --generate_batch_files_script '{generate_batch_files_script}' --conda_init_script '{conda_init_script}' --cmip6_directory '{cmip6_directory}' --regrid_batch_dir '{regrid_batch_dir}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_generate_batch_files_script} --generate_batch_files_script '{generate_batch_files_script}' --conda_init_script '{conda_init_script}' --conda_env_name {conda_env_name} --cmip6_directory '{cmip6_directory}' --regrid_batch_dir '{regrid_batch_dir}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
     )
 
     # Wait for the command to finish and get the exit status
@@ -197,6 +213,7 @@ def create_and_run_slurm_scripts(
     regrid_dir,
     regrid_batch_dir,
     conda_init_script,
+    conda_env_name,
     regrid_script,
     target_grid_fp,
     no_clobber,
@@ -215,12 +232,13 @@ def create_and_run_slurm_scripts(
     - regrid_dir: Path to directory where regridded files are written
     - regrid_batch_dir: Directory of batch files
     - conda_init_script: Script to initialize conda during slurm jobs
+    - conda_env_name: Name of the Conda environment to activate
     - regrid_script: Location of regrid.py script in the repo
     - target_grid_fp: Path to file used as the regridding target
     - no_clobber: Do not overwrite regidded files if they exist
     """
 
-    cmd = f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --conda_init_script '{conda_init_script}' --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
+    cmd = f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --conda_init_script '{conda_init_script}' --conda_env_name {conda_env_name} --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
 
     if no_clobber:
         cmd += " --no_clobber"
@@ -362,6 +380,7 @@ def run_qc(
     cmip6_directory,
     repo_regridding_directory,
     conda_init_script,
+    conda_env_name,
     run_qc_script,
     qc_script,
     visual_qc_notebook,
@@ -372,7 +391,7 @@ def run_qc(
 ):
 
     stdin_, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_qc_script} --qc_script '{qc_script}' --visual_qc_notebook '{visual_qc_notebook}' --conda_init_script '{conda_init_script}' --cmip6_directory '{cmip6_directory}' --output_directory '{output_directory}' --repo_regridding_directory '{repo_regridding_directory}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_qc_script} --qc_script '{qc_script}' --visual_qc_notebook '{visual_qc_notebook}' --conda_init_script '{conda_init_script}' --conda_env_name '{conda_env_name}' --cmip6_directory '{cmip6_directory}' --output_directory '{output_directory}' --repo_regridding_directory '{repo_regridding_directory}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
     )
 
     # Wait for the command to finish and get the exit status

--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -188,7 +188,7 @@ def run_generate_batch_files(
     - conda_env_name: Name of the Conda environment to activate
     - regrid_script: Location of regrid.py script in the repo
     - target_grid_fp: Path to file used as the regridding target
-    - no_clobber: Do not overwrite regidded files if they exist
+    - no_clobber: Do not overwrite regridded files if they exist
     """
     stdin_, stdout, stderr = ssh.exec_command(
         f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_generate_batch_files_script} --generate_batch_files_script '{generate_batch_files_script}' --conda_init_script '{conda_init_script}' --conda_env_name {conda_env_name} --cmip6_directory '{cmip6_directory}' --regrid_batch_dir '{regrid_batch_dir}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
@@ -235,7 +235,7 @@ def create_and_run_slurm_scripts(
     - conda_env_name: Name of the Conda environment to activate
     - regrid_script: Location of regrid.py script in the repo
     - target_grid_fp: Path to file used as the regridding target
-    - no_clobber: Do not overwrite regidded files if they exist
+    - no_clobber: Do not overwrite regridded files if they exist
     """
 
     cmd = f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --conda_init_script '{conda_init_script}' --conda_env_name {conda_env_name} --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"

--- a/regridding/regridding_functions.py
+++ b/regridding/regridding_functions.py
@@ -169,11 +169,11 @@ def run_generate_batch_files(
     run_generate_batch_files_script,
     cmip6_directory,
     regrid_batch_dir,
-    slurm_email,
     vars,
+    freqs,
 ):
     stdin_, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_generate_batch_files_script} --generate_batch_files_script '{generate_batch_files_script}' --conda_init_script '{conda_init_script}' --cmip6_directory '{cmip6_directory}' --regrid_batch_dir '{regrid_batch_dir}' --slurm_email '{slurm_email}' --vars '{vars}'"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_generate_batch_files_script} --generate_batch_files_script '{generate_batch_files_script}' --conda_init_script '{conda_init_script}' --cmip6_directory '{cmip6_directory}' --regrid_batch_dir '{regrid_batch_dir}' --vars '{vars}' --freqs '{freqs}'"
     )
 
     # Wait for the command to finish and get the exit status
@@ -194,11 +194,12 @@ def create_and_run_slurm_scripts(
     slurm_dir,
     regrid_dir,
     regrid_batch_dir,
-    slurm_email,
     conda_init_script,
     regrid_script,
     target_grid_fp,
     no_clobber,
+    vars,
+    freqs,
 ):
     """
     Task to create and submit Slurm scripts to regrid batches of CMIP6 data.
@@ -209,14 +210,13 @@ def create_and_run_slurm_scripts(
     - slurm_dir: Directory to save slurm sbatch files
     - regrid_dir: Path to directory where regridded files are written
     - regrid_batch_dir: Directory of batch files
-    - slurm_email: Email address to send slurm emails to
     - conda_init_script: Script to initialize conda during slurm jobs
     - regrid_script: Location of regrid.py script in the repo
     - target_grid_fp: Path to file used as the regridding target
     - no_clobber: Do not overwrite regidded files if they exist
     """
 
-    cmd = f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --slurm_email '{slurm_email}' --conda_init_script '{conda_init_script}' --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}'"
+    cmd = f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --slurm_dir '{slurm_dir}' --regrid_dir '{regrid_dir}'  --regrid_batch_dir '{regrid_batch_dir}' --conda_init_script '{conda_init_script}' --regrid_script '{regrid_script}' --target_grid_fp '{target_grid_fp}' --vars '{vars}' --freqs '{freqs}'"
 
     if no_clobber:
         cmd += " --no_clobber"
@@ -308,6 +308,50 @@ def validate_vars(vars):
 
 
 @task
+def validate_freqs(freq_str):
+    """
+    Task to validate frequencies to work on.
+    Parameters:
+    - freqs_str: a string of variable ids separated by white space (e.g., 'pr tas ta') or variable group names found in luts.py (e.g. 'land')
+    """
+
+    if freq_str == "all":
+        return (" ").join(all_freqs)
+    else:
+        freqs = freq_str.split()
+        assert all(x in all_freqs for x in freqs), "Variables not valid."
+        return freq_str
+
+
+@task
+def validate_models(models_str):
+    """Task to validate string of models to work on.
+    Parameters:
+    - models_str: string of models separated by white space (e.g., 'CESM2 GFDL-ESM4')
+    """
+    if models_str == "all":
+        return (" ").join(all_models)
+    else:
+        models = models_str.split()
+        assert all(x in all_models for x in models), "Models not valid."
+        return models_str
+
+
+@task
+def validate_scenarios(scenarios_str):
+    """Task to validate string of scenarios to work on.
+    Parameters:
+    - scenarios_str: string of scenarios separated by white space (e.g., 'historical ssp585')
+    """
+    if scenarios_str == "all":
+        return (" ").join(all_scenarios)
+    else:
+        scenarios = scenarios_str.split()
+        assert all(x in all_scenarios for x in scenarios), "Scenarios not valid."
+        return scenarios_str
+
+
+@task
 def run_qc(
     ssh,
     output_directory,
@@ -318,11 +362,13 @@ def run_qc(
     qc_script,
     visual_qc_notebook,
     vars,
-    slurm_email,
+    freqs,
+    models,
+    scenarios,
 ):
 
     stdin_, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_qc_script} --qc_script '{qc_script}' --visual_qc_notebook '{visual_qc_notebook}' --conda_init_script '{conda_init_script}' --cmip6_directory '{cmip6_directory}' --output_directory '{output_directory}' --repo_regridding_directory '{repo_regridding_directory}' --slurm_email '{slurm_email}' --vars '{vars}'"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {run_qc_script} --qc_script '{qc_script}' --visual_qc_notebook '{visual_qc_notebook}' --conda_init_script '{conda_init_script}' --cmip6_directory '{cmip6_directory}' --output_directory '{output_directory}' --repo_regridding_directory '{repo_regridding_directory}' --vars '{vars}' --freqs '{freqs}' --models '{models}' --scenarios '{scenarios}'"
     )
 
     # Wait for the command to finish and get the exit status


### PR DESCRIPTION
This PR adds parameters for frequency, model, and scenario to the regridding pipeline flow. This enhancement permits the processing of any single combination of model, scenario, variable, and frequency. The default option is "all" for each of these, meaning all available data.

To test, execute the regrid CMIP6 flow like you would with any other prefect flow. Use /beegfs/CMIP6/arctic-cmip6/CMIP6 as the `cmip6_directory`, and use `fix_regrid` for the `branch_name`. 

Try testing a few different combinations of things, such as 
1) a single frequency, model, scenario, and variable;
2) then maybe 2 or more for each, 
3) then the default "all" for each, to run the whole shebang. 

You can test with either a personal directory in Chinook, or the `snapdata` directory.

To verify the regridding, you can look into the QC files in `<scratch_directory>/cmip6_regridding/qc/`. You can view the `qc_error.txt` fiel to make sure there are no errors written there, and check out the rendered HTML QC notebook that will be saved to `visual_qc_out.html` (I copy to it locally via SCP but there might be a way to view on Chinook?) to check out visuals of the new data. 

Please share any and all suggestions! This is a critical part of the CMIP6 pipeline. While I anticipate running this less and less frequently, I'm open to all ideas for polishing it and trying to improve the quality of the data product. 


closes #20 #41 
