### PR TITLE
Adds API recache functionality to Prefect scripts

### DIFF
--- a/recache_api/luts.py
+++ b/recache_api/luts.py
@@ -1,0 +1,17 @@
+cached_urls = [
+    "/eds/all/",
+    "/alfresco/flammability/local/",
+    "/alfresco/veg_type/local/",
+    "/beetles/point/",
+    "/elevation/point/",
+    "/taspr/point/",
+    "/indicators/base/point/",
+    "/ncr/permafrost/point/",
+    "/eds/hydrology/point/",
+    "/alfresco/flammability/area/",
+    "/alfresco/veg_type/area/",
+    "/beetles/area/",
+    "/elevation/area/",
+    "/taspr/area/",
+    "/indicators/base/area/",
+]

--- a/recache_api/recache.py
+++ b/recache_api/recache.py
@@ -1,0 +1,18 @@
+from prefect import flow
+import recache_tasks
+from luts import cached_urls
+
+
+@flow(log_prints=True)
+def recache_api(cached_url_list=cached_urls):
+    recache_tasks.run_recache(cached_url_list)
+
+
+if __name__ == "__main__":
+    recache_api.serve(
+        name="Recache the data API",
+        tags=["Recache API"],
+        parameters={
+            "cached_url_list": cached_urls,
+        },
+    )

--- a/recache_api/recache.py
+++ b/recache_api/recache.py
@@ -5,7 +5,7 @@ from luts import cached_urls
 
 @flow(log_prints=True)
 def recache_api(cached_url_list=cached_urls):
-    recache_tasks.run_recache(cached_url_list)
+    recache_tasks.recache_api(cached_url_list)
 
 
 if __name__ == "__main__":

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -50,9 +50,9 @@ def get_all_route_endpoints(curr_route, curr_type):
     # For each JSON item in the JSON object array
     for place in places:
         if (
-            place["properties"]["region"] is "Alaska"
-            or place["properties"]["region"] is "Yukon"
-            or place["properties"]["region"] is "Northwest Territories"
+            place["properties"]["region"] == "Alaska"
+            or place["properties"]["region"] == "Yukon"
+            or place["properties"]["region"] == "Northwest Territories"
         ):
             get_endpoint(curr_route, curr_type, place["properties"])
 

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -33,7 +33,7 @@ def get_all_route_endpoints(curr_route, curr_type):
     if curr_type == "community":
         places_url = (
             GS_BASE_URL
-            + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_communities&outputFormat=application/json&propertyName=latitude,longitude"
+            + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_communities&outputFormat=application/json&propertyName=latitude,longitude,region"
         )
         response = requests.get(places_url)
         places_data = response.json()
@@ -41,7 +41,7 @@ def get_all_route_endpoints(curr_route, curr_type):
     else:
         places_url = (
             GS_BASE_URL
-            + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_areas&outputFormat=application/json&propertyName=id"
+            + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_areas&outputFormat=application/json&propertyName=id,region"
         )
         response = requests.get(places_url)
         places_data = response.json()
@@ -49,7 +49,12 @@ def get_all_route_endpoints(curr_route, curr_type):
 
     # For each JSON item in the JSON object array
     for place in places:
-        get_endpoint(curr_route, curr_type, place["properties"])
+        if (
+            place["properties"]["region"] is "Alaska"
+            or place["properties"]["region"] is "Yukon"
+            or place["properties"]["region"] is "Northwest Territories"
+        ):
+            get_endpoint(curr_route, curr_type, place["properties"])
 
 
 def get_endpoint(curr_route, curr_type, place):

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -35,13 +35,17 @@ def get_all_route_endpoints(curr_route, curr_type):
             GS_BASE_URL
             + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_communities&outputFormat=application/json&propertyName=latitude,longitude"
         )
-        places = requests.get(places_url)["features"]
+        response = requests.get(places_url)
+        places_data = response.json()
+        places = places_data["features"]
     else:
         places_url = (
             GS_BASE_URL
             + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_areas&outputFormat=application/json&propertyName=id"
         )
-        places = requests.get(places_url)["features"]
+        response = requests.get(places_url)
+        places_data = response.json()
+        places = places_data["features"]
 
     # For each JSON item in the JSON object array
     for place in places:

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -1,0 +1,80 @@
+import requests
+from prefect import task
+
+
+@task(name="Recache API")
+def recache_api(cached_urls):
+
+    for route in cached_urls:
+        if (
+            route.find("point") != -1
+            or route.find("local") != -1
+            or route.find("all") != -1
+        ) and (route.find("lat") == -1):
+            get_all_route_endpoints(route, "community")
+        elif route.find("area") != -1 and route.find("var_id") == -1:
+            get_all_route_endpoints(route, "area")
+
+
+def get_all_route_endpoints(curr_route, curr_type):
+    """Generates all possible endpoints given a particular route & type
+
+    Args:
+        curr_route - Current route ex. https://earthmaps.io/taspr/huc/
+        curr_type - One of the many types availabe such as community or huc.
+
+    Returns:
+        Nothing.
+    """
+    GS_BASE_URL = "https://gs.earthmaps.io/geoserver/"
+
+    # Opens the JSON file for the current type and replaces the "variable" portions
+    # of the route to allow for the JSON items to fill in those fields.
+    if curr_type == "community":
+        places_url = (
+            GS_BASE_URL
+            + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_communities&outputFormat=application/json&propertyName=latitude,longitude"
+        )
+        places = requests.get(places_url)["features"]
+    else:
+        places_url = (
+            GS_BASE_URL
+            + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_areas&outputFormat=application/json&propertyName=id"
+        )
+        places = requests.get(places_url)["features"]
+
+    # For each JSON item in the JSON object array
+    for place in places:
+        get_endpoint(curr_route, curr_type, place["properties"])
+
+
+def get_endpoint(curr_route, curr_type, place):
+    """Requests a specific endpoint of the API with parameters coming from
+    the JSON of communities, HUCs, or protected areas.
+
+     Args:
+         curr_route - Current route ex. https://earthmaps.io/taspr/huc/
+         curr_type - One of three types: community, huc, or pa
+         place - One item of the JSON for community, huc, or protected area
+
+     Returns:
+         Nothing.
+
+    """
+    # Build the URL to query based on type
+    if curr_type == "community":
+        url = (
+            "https://earthmaps.io"
+            + curr_route
+            + str(place["latitude"])
+            + "/"
+            + str(place["longitude"])
+        )
+    else:
+        url = "https://earthmaps.io" + curr_route + str(place["id"])
+
+    print(f"Running URL: {url}")
+
+    # Collects returned status from GET request
+    status = requests.get(url)
+    print(f"Status Response: {status}")


### PR DESCRIPTION
This PR adds the ability to run a Prefect script to recache the API after dropping the entirety of the cache, or only a subsection of the API if desired. You can specify just the endpoints that you want to recache to speed up the process if only a small amount of the API needs to be recached after dropping only specific endpoints.

To test, start this code up on something like Zeus and try running it against only "/beetles/point/". You should quickly see a resulting 200 HTTP code for each of the points in question if they are contained within the cache.