### PR TITLE
Add E3SM

### DIFF
--- a/regridding/luts.py
+++ b/regridding/luts.py
@@ -76,7 +76,8 @@ all_models = [
     "MRI-ESM2-0",
     "NorESM2-MM",
     "TaiESM1",
-    "E3SM-Project",
+    "E3SM-1-1",
+    "E3SM-2-0",
 ]
 
 all_scenarios = ["historical", "ssp126", "ssp245", "ssp370", "ssp585"]

--- a/regridding/luts.py
+++ b/regridding/luts.py
@@ -76,6 +76,7 @@ all_models = [
     "MRI-ESM2-0",
     "NorESM2-MM",
     "TaiESM1",
+    "E3SM-Project",
 ]
 
 all_scenarios = ["historical", "ssp126", "ssp245", "ssp370", "ssp585"]


### PR DESCRIPTION
This PR simply adds the E3SM models into the regridding `luts.py` so that including these model names in the run parameters will not fail the parameter validation.