### PR TITLE
Add more indicators

### DIFF
--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -19,7 +19,6 @@ def generate_indicators(
     models,
     scenarios,
     input_dir,
-    hist_dir,
 ):
     # Create an SSH client
     ssh = paramiko.SSHClient()
@@ -41,7 +40,7 @@ def generate_indicators(
         )
 
         indicator_functions.create_and_run_slurm_script(
-            ssh, indicators, models, scenarios, working_directory, input_dir, hist_dir
+            ssh, indicators, models, scenarios, working_directory, input_dir
         )
 
         job_ids = indicator_functions.get_job_ids(ssh, ssh_username)
@@ -54,7 +53,7 @@ def generate_indicators(
 
         indicator_functions.wait_for_jobs_completion(ssh, job_ids)
 
-        indicator_functions.visual_qc_nb(ssh, working_directory, input_dir, hist_dir)
+        indicator_functions.visual_qc_nb(ssh, working_directory, input_dir)
 
         job_ids = indicator_functions.get_job_ids(ssh, ssh_username)
 
@@ -73,7 +72,6 @@ if __name__ == "__main__":
     models = "CESM2 GFDL-ESM4 TaiESM1"
     scenarios = "historical ssp126 ssp245 ssp370 ssp585"
     input_dir = Path("/import/beegfs/CMIP6/arctic-cmip6/regrid/")
-    hist_dir = Path("/import/beegfs/CMIP6/arctic-cmip6/daymet/")
 
     generate_indicators.serve(
         name="generate-indicators",
@@ -87,6 +85,5 @@ if __name__ == "__main__":
             "models": models,
             "scenarios": scenarios,
             "input_dir": input_dir,
-            "hist_dir": hist_dir,
         },
     )

--- a/indicators/generate_indicators.py
+++ b/indicators/generate_indicators.py
@@ -19,6 +19,7 @@ def generate_indicators(
     models,
     scenarios,
     input_dir,
+    hist_dir,
 ):
     # Create an SSH client
     ssh = paramiko.SSHClient()
@@ -40,7 +41,7 @@ def generate_indicators(
         )
 
         indicator_functions.create_and_run_slurm_script(
-            ssh, indicators, models, scenarios, working_directory, input_dir
+            ssh, indicators, models, scenarios, working_directory, input_dir, hist_dir
         )
 
         job_ids = indicator_functions.get_job_ids(ssh, ssh_username)
@@ -53,7 +54,7 @@ def generate_indicators(
 
         indicator_functions.wait_for_jobs_completion(ssh, job_ids)
 
-        indicator_functions.visual_qc_nb(ssh, working_directory, input_dir)
+        indicator_functions.visual_qc_nb(ssh, working_directory, input_dir, hist_dir)
 
         job_ids = indicator_functions.get_job_ids(ssh, ssh_username)
 
@@ -72,6 +73,7 @@ if __name__ == "__main__":
     models = "CESM2 GFDL-ESM4 TaiESM1"
     scenarios = "historical ssp126 ssp245 ssp370 ssp585"
     input_dir = Path("/import/beegfs/CMIP6/arctic-cmip6/regrid/")
+    hist_dir = Path("/import/beegfs/CMIP6/arctic-cmip6/daymet/")
 
     generate_indicators.serve(
         name="generate-indicators",
@@ -85,5 +87,6 @@ if __name__ == "__main__":
             "models": models,
             "scenarios": scenarios,
             "input_dir": input_dir,
+            "hist_dir": hist_dir,
         },
     )

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -2,7 +2,7 @@ from time import sleep
 from prefect import task
 import paramiko
 
-all_indicators = "rx1day su dw ftc"
+all_indicators = "rx1day rx5day r10mm su dw ftc cdd cwd hd cd"
 
 all_models = "CESM2 CNRM-CM6-1-HR E3SM-2-0 EC-Earth3-Veg GFDL-ESM4 HadGEM3-GC31-LL HadGEM3-GC31-MM KACE-1-0-G MIROC6 MPI-ESM1-2-HR MRI-ESM2-0 NorESM2-MM TaiESM1"
 

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -268,8 +268,6 @@ def qc(ssh, working_dir, input_dir):
     - working_dir: Directory to where all of the processing takes place
     """
 
-    conda_init_script = f"{working_dir}/cmip6-utils/indicators/conda_init.sh"
-
     run_qc_script = f"{working_dir}/cmip6-utils/indicators/run_qc.py"
     qc_script = f"{working_dir}/cmip6-utils/indicators/qc.py"
     output_dir = f"{working_dir}/cmip6_indicators"

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -168,7 +168,7 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
 
 @task
 def create_and_run_slurm_script(
-    ssh, indicators, models, scenarios, working_dir, input_dir
+    ssh, indicators, models, scenarios, working_dir, input_dir, hist_dir
 ):
     """
     Task to create and run a Slurm script to run the indicator calculation scripts.
@@ -180,6 +180,7 @@ def create_and_run_slurm_script(
     - scenarios: Space-separated list of scenarios to calculate indicators for
     - working_dir: Directory to where all of the processing takes place
     - input_dir: Directory containing the input data for the indicators
+    - hist_dir: Directory containing the historical data
     """
 
     if indicators == "all":
@@ -192,7 +193,7 @@ def create_and_run_slurm_script(
     slurm_script = f"{working_dir}/cmip6-utils/indicators/slurm.py"
 
     stdin, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --working_dir '{working_dir}'"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --hist_dir '{hist_dir}' --working_dir '{working_dir}'"
     )
 
     # Wait for the command to finish and get the exit status
@@ -300,7 +301,7 @@ def qc(ssh, working_dir, input_dir):
 
 
 @task
-def visual_qc_nb(ssh, working_dir, input_dir):
+def visual_qc_nb(ssh, working_dir, input_dir, hist_dir):
     """
     Task to run the visual quality control (QC) notebook to check the output of the indicator calculations.
 
@@ -319,6 +320,7 @@ def visual_qc_nb(ssh, working_dir, input_dir):
     stdin, stdout, stderr = ssh.exec_command(
         f"python {run_visual_qc_script} \
             --input_dir '{input_dir}' \
+            --hist_dir '{hist_dir}' \
             --slurm_dir '{slurm_dir}' \
             --working_dir '{working_dir}' \
             --visual_qc_nb '{visual_qc_nb}' \

--- a/indicators/indicator_functions.py
+++ b/indicators/indicator_functions.py
@@ -2,7 +2,7 @@ from time import sleep
 from prefect import task
 import paramiko
 
-all_indicators = "rx1day rx5day r10mm su dw ftc cdd cwd hd cd"
+all_indicators = "rx1day rx5day r10mm su dw ftc cdd cwd hd cd csdi wsdi"
 
 all_models = "CESM2 CNRM-CM6-1-HR E3SM-2-0 EC-Earth3-Veg GFDL-ESM4 HadGEM3-GC31-LL HadGEM3-GC31-MM KACE-1-0-G MIROC6 MPI-ESM1-2-HR MRI-ESM2-0 NorESM2-MM TaiESM1"
 
@@ -168,7 +168,7 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
 
 @task
 def create_and_run_slurm_script(
-    ssh, indicators, models, scenarios, working_dir, input_dir, hist_dir
+    ssh, indicators, models, scenarios, working_dir, input_dir
 ):
     """
     Task to create and run a Slurm script to run the indicator calculation scripts.
@@ -180,7 +180,6 @@ def create_and_run_slurm_script(
     - scenarios: Space-separated list of scenarios to calculate indicators for
     - working_dir: Directory to where all of the processing takes place
     - input_dir: Directory containing the input data for the indicators
-    - hist_dir: Directory containing the historical data
     """
 
     if indicators == "all":
@@ -193,7 +192,7 @@ def create_and_run_slurm_script(
     slurm_script = f"{working_dir}/cmip6-utils/indicators/slurm.py"
 
     stdin, stdout, stderr = ssh.exec_command(
-        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --hist_dir '{hist_dir}' --working_dir '{working_dir}'"
+        f"export PATH=$PATH:/opt/slurm-22.05.4/bin:/opt/slurm-22.05.4/sbin:$HOME/miniconda3/bin && python {slurm_script} --indicators '{indicators}' --models '{models}' --scenarios '{scenarios}' --input_dir '{input_dir}' --working_dir '{working_dir}'"
     )
 
     # Wait for the command to finish and get the exit status
@@ -301,7 +300,7 @@ def qc(ssh, working_dir, input_dir):
 
 
 @task
-def visual_qc_nb(ssh, working_dir, input_dir, hist_dir):
+def visual_qc_nb(ssh, working_dir, input_dir):
     """
     Task to run the visual quality control (QC) notebook to check the output of the indicator calculations.
 
@@ -320,7 +319,6 @@ def visual_qc_nb(ssh, working_dir, input_dir, hist_dir):
     stdin, stdout, stderr = ssh.exec_command(
         f"python {run_visual_qc_script} \
             --input_dir '{input_dir}' \
-            --hist_dir '{hist_dir}' \
             --slurm_dir '{slurm_dir}' \
             --working_dir '{working_dir}' \
             --visual_qc_nb '{visual_qc_nb}' \


### PR DESCRIPTION
This PR adds the `rx5day`, `r10mm`, `cdd`, `cwd`, `hd`, and `cd` indicators, and also sets up the pipeline to add the `wsdi` and `csdi` indicators once a pan-Arctic daily historical dataset is identified.

To test, start the `generate-indicators` Prefect flow and point the flow parameters towards the  [more_indicators](https://github.com/ua-snap/cmip6-utils/tree/more_indicators) branch of the `cmip6-utils` repo. Generate the indicators, and review the QC files.

See below for example flow parameters. Note the new `hist_dir` parameter. For now, this does not do anything as it will only be used when the `wsdi` and `csdi` indicators are implemented. 

```
{
  "ssh_username": "jdpaul3",
  "ssh_private_key_path": "/Users/joshpaul/.ssh/id_rsa",
  "branch_name": "more_indicators",
  "working_directory": "/import/beegfs/CMIP6/jdpaul3/cmip6_indicators_test",
  "indicators": "all",
  "models": "all",
  "scenarios": "all",
  "input_dir": "/import/beegfs/CMIP6/jdpaul3/CMIP6_common_regrid/regrid",
  "hist_dir": "/import/beegfs/CMIP6/arctic-cmip6/daymet"
}
```