### PR TITLE
Fix to recache API functionality for areas

### DIFF
--- a/recache_api/luts.py
+++ b/recache_api/luts.py
@@ -5,7 +5,7 @@ cached_urls = [
     "/beetles/point/",
     "/elevation/point/",
     "/taspr/point/",
-    "/indicators/base/point/",
+    "/indicators/cmip5/point/",
     "/ncr/permafrost/point/",
     "/eds/hydrology/point/",
     "/alfresco/flammability/area/",
@@ -13,5 +13,5 @@ cached_urls = [
     "/beetles/area/",
     "/elevation/area/",
     "/taspr/area/",
-    "/indicators/base/area/",
+    "/indicators/cmip5/area/",
 ]

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -49,13 +49,14 @@ def get_all_route_endpoints(curr_route, curr_type):
 
     # For each JSON item in the JSON object array
     for place in places:
-        if curr_type == "community" and (
-            place["properties"]["region"] == "Alaska"
-            or place["properties"]["region"] == "Yukon"
-            or place["properties"]["region"] == "Northwest Territories"
-        ):
-            get_endpoint(curr_route, curr_type, place["properties"])
-        elif curr_type == "area" and place["properties"]["area_type"] != "HUC12":
+        if (
+            curr_type == "community"
+            and (
+                place["properties"]["region"] == "Alaska"
+                or place["properties"]["region"] == "Yukon"
+                or place["properties"]["region"] == "Northwest Territories"
+            )
+        ) or (curr_type == "area" and place["properties"]["area_type"] != "HUC12"):
             get_endpoint(curr_route, curr_type, place["properties"])
 
 

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -41,19 +41,23 @@ def get_all_route_endpoints(curr_route, curr_type):
     else:
         places_url = (
             GS_BASE_URL
-            + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_areas&outputFormat=application/json&propertyName=id,region"
+            + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_areas&outputFormat=application/json&propertyName=id,area_type"
         )
+        print("Places URL: ", places_url)
+        print("Current type: ", curr_type)
         response = requests.get(places_url)
         places_data = response.json()
         places = places_data["features"]
 
     # For each JSON item in the JSON object array
     for place in places:
-        if (
+        if curr_type == "community" and (
             place["properties"]["region"] == "Alaska"
             or place["properties"]["region"] == "Yukon"
             or place["properties"]["region"] == "Northwest Territories"
         ):
+            get_endpoint(curr_route, curr_type, place["properties"])
+        elif curr_type == "area" and place["properties"]["area_type"] != "HUC12":
             get_endpoint(curr_route, curr_type, place["properties"])
 
 

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -43,8 +43,6 @@ def get_all_route_endpoints(curr_route, curr_type):
             GS_BASE_URL
             + f"wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=all_boundaries:all_areas&outputFormat=application/json&propertyName=id,area_type"
         )
-        print("Places URL: ", places_url)
-        print("Current type: ", curr_type)
         response = requests.get(places_url)
         places_data = response.json()
         places = places_data["features"]

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -47,14 +47,14 @@ def get_all_route_endpoints(curr_route, curr_type):
         places_data = response.json()
         places = places_data["features"]
 
-    # For each JSON item in the JSON object array
+    # We are excluding HUC12 areas because they add a lot of additional caching
+    # that is not used in any of our apps.
     for place in places:
         if (
             curr_type == "community"
             and (
-                place["properties"]["region"] == "Alaska"
-                or place["properties"]["region"] == "Yukon"
-                or place["properties"]["region"] == "Northwest Territories"
+                place["properties"]["region"]
+                in ["Alaska", "Yukon", "Northwest Territories"]
             )
         ) or (curr_type == "area" and place["properties"]["area_type"] != "HUC12"):
             get_endpoint(curr_route, curr_type, place["properties"])


### PR DESCRIPTION
This PR fixes the recache API functionality for areas as they do not contain regions in their properties. This instead will cache all areas that are not HUC12s, since those are included in the all_areas shapefile now. 