### PR TITLE
Recategorize or omit air quality sensors based on feedback

### DIFF
--- a/wildfire_map/purple_air/get_purple_air.py
+++ b/wildfire_map/purple_air/get_purple_air.py
@@ -91,9 +91,9 @@ def fetch_dec_air_data():
         "Quant_MOD00443",
         "Quant_MOD00463",
         "Quant_MOD00471",
-        "Quant_MOD00651,"
-        "Quant_MOD00652,"
-        "Quant_MOD00665,",
+        "Quant_MOD00651",
+        "Quant_MOD00652",
+        "Quant_MOD00665",
     ]
 
     for feature in data["features"]:

--- a/wildfire_map/purple_air/get_purple_air.py
+++ b/wildfire_map/purple_air/get_purple_air.py
@@ -89,8 +89,8 @@ def fetch_dec_air_data():
     ]
     sensors_to_omit = [
         "Quant_MOD00443",
-        "Quant_MOD00463,"
-        "Quant_MOD00471,"
+        "Quant_MOD00463",
+        "Quant_MOD00471",
         "Quant_MOD00651,"
         "Quant_MOD00652,"
         "Quant_MOD00665,",

--- a/wildfire_map/purple_air/get_purple_air.py
+++ b/wildfire_map/purple_air/get_purple_air.py
@@ -74,10 +74,37 @@ def fetch_dec_air_data():
     response.raise_for_status()
     data = response.json()
     returned_data = list()
+
+    # Recategorize or omit sensors based on their sensor_id.
+    # More info here: https://github.com/ua-snap/alaska-wildfires/issues/224
+    conocophillips_sensors = [
+        "Nuiqsut",
+    ]
+    blm_sensors = [
+        "BLM_Kaktovik",
+    ]
+    louden_tribe_sensors = [
+        "Quant_MOD00758",
+        "Quant_MOD00759",
+    ]
+    sensors_to_omit = [
+        "Quant_MOD00443",
+        "Quant_MOD00463,"
+        "Quant_MOD00471,"
+        "Quant_MOD00651,"
+        "Quant_MOD00652,"
+        "Quant_MOD00665,",
+    ]
+
     for feature in data["features"]:
         # If pm25calibrated is None, skip this DEC sensor
         if feature["properties"]["pm25calibrated"] is None:
             continue
+
+        sensor_id = feature["properties"]["sensor_id"]
+        if sensor_id in sensors_to_omit:
+            continue
+
         new_feature = list()
         new_feature.append(feature["properties"]["OBJECTID"])  # objectId
         new_feature.append(
@@ -91,8 +118,19 @@ def fetch_dec_air_data():
         new_feature.append(
             feature["properties"]["pm25calibrated"]
         )  # AQI PM2.5 1hr, this field is already converted to AQI
-        new_feature.append("dec")  # type
+
+        # Assign type for each sensor
+        if sensor_id in conocophillips_sensors:
+            new_feature.append("conocophillips")
+        elif sensor_id in blm_sensors:
+            new_feature.append("blm")
+        elif sensor_id in louden_tribe_sensors:
+            new_feature.append("louden_tribe")
+        else:
+            new_feature.append("dec")
+
         returned_data.append(new_feature)
+
     return returned_data
 
 


### PR DESCRIPTION
Xref: https://github.com/ua-snap/alaska-wildfires/issues/224

This PR implements the sensor type recategorization & sensor omission changes described in https://github.com/ua-snap/alaska-wildfires/issues/224 when `purple_air_pm25.shp` is generated through Prefect.

The code diff is pretty self-explanatory, but you'll see that:

- 4 sensors have their `type` changed based on their `sensor_id` (actually only 3 sensors currently because `Quant_MOD00759` is not yet online).
- 6 sensors have been removed entirely. This is an odd case, though, because I could not find any records in `data["features"]` matching these `sensor_id`s, or even any matching `sensor_id` substring for just `443`, `463`, etc. So, it appears that these sensors don't even show up in the upstream data we're working from. @BobTorgerson, can you think of any reason that would explain this? Otherwise, we can communicate back that our code is explicitly omitting these sensors, but it also appears they were omitted already.

To test, just run the `wildfire_map/purple_air/get_purple_air.py` script and verify that the generated `purple_air_pm25.shp` reflects the changes described above.