### PR TITLE
Refactoring of API recache functionality 

### DIFF
--- a/recache_api/luts.py
+++ b/recache_api/luts.py
@@ -1,18 +1,18 @@
-ncr_cached_urls = [
-    "/alfresco/flammability/local/",
-    "/alfresco/veg_type/local/",
-    "/beetles/point/",
-    "/elevation/point/",
-    "/taspr/point/",
-    "/indicators/base/point/",
-    "/ncr/permafrost/point/",
-    "/eds/hydrology/point/",
-    "/alfresco/flammability/area/",
-    "/alfresco/veg_type/area/",
-    "/beetles/area/",
-    "/elevation/area/",
-    "/taspr/area/",
-    "/indicators/base/area/",
-]
+ncr_cached_urls = {
+    "/alfresco/flammability/local/": "community",
+    "/alfresco/veg_type/local/": "community",
+    "/beetles/point/": "community",
+    "/elevation/point/": "community",
+    "/taspr/point/": "community",
+    "/indicators/base/point/": "community",
+    "/ncr/permafrost/point/": "community",
+    "/eds/hydrology/point/": "community",
+    "/alfresco/flammability/area/": "area",
+    "/alfresco/veg_type/area/": "area",
+    "/beetles/area/": "area",
+    "/elevation/area/": "area",
+    "/taspr/area/": "area",
+    "/indicators/base/area/": "area",
+}
 
 eds_cached_url = "/eds/all/"

--- a/recache_api/luts.py
+++ b/recache_api/luts.py
@@ -4,7 +4,7 @@ ncr_cached_urls = [
     "/beetles/point/",
     "/elevation/point/",
     "/taspr/point/",
-    "/indicators/cmip5/point/",
+    "/indicators/base/point/",
     "/ncr/permafrost/point/",
     "/eds/hydrology/point/",
     "/alfresco/flammability/area/",
@@ -12,7 +12,7 @@ ncr_cached_urls = [
     "/beetles/area/",
     "/elevation/area/",
     "/taspr/area/",
-    "/indicators/cmip5/area/",
+    "/indicators/base/area/",
 ]
 
 eds_cached_url = "/eds/all/"

--- a/recache_api/luts.py
+++ b/recache_api/luts.py
@@ -1,5 +1,4 @@
-cached_urls = [
-    "/eds/all/",
+ncr_cached_urls = [
     "/alfresco/flammability/local/",
     "/alfresco/veg_type/local/",
     "/beetles/point/",
@@ -15,3 +14,5 @@ cached_urls = [
     "/taspr/area/",
     "/indicators/cmip5/area/",
 ]
+
+eds_cached_url = "/eds/all/"

--- a/recache_api/recache.py
+++ b/recache_api/recache.py
@@ -1,11 +1,10 @@
 from prefect import flow
 import recache_tasks
-from luts import cached_urls
 
 
 @flow(log_prints=True)
-def recache_api(cached_url_list=cached_urls):
-    recache_tasks.recache_api(cached_url_list)
+def recache_api(cached_apps, cache_url):
+    recache_tasks.recache_api(cached_apps, cache_url)
 
 
 if __name__ == "__main__":
@@ -13,6 +12,7 @@ if __name__ == "__main__":
         name="Recache the data API",
         tags=["Recache API"],
         parameters={
-            "cached_url_list": cached_urls,
+            "cached_apps": ["eds", "ncr"],
+            "cache_url": "https://earthmaps.io",
         },
     )

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -65,7 +65,7 @@ def get_all_route_endpoints(curr_route, curr_type, cache_url):
 
 def get_endpoint(curr_route, curr_type, place, cache_url):
     """Requests a specific endpoint of the API with parameters coming from
-    the JSON of communities, HUCs, or protected areas.
+    the JSON of communities or areas.
 
      Args:
          curr_route - Current route ex. /taspr/huc/

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -30,7 +30,7 @@ def get_all_route_endpoints(curr_route, curr_type, cache_url):
     """Generates all possible endpoints given a particular route & type
 
     Args:
-        curr_route - Current route ex. /taspr/huc/
+        curr_route - Current route ex. /taspr/area/
         curr_type - Either community or area
         cache_url - The base URL for the API cache, e.g., https://earthmaps.io
 
@@ -68,7 +68,7 @@ def get_endpoint(curr_route, curr_type, place, cache_url):
     the JSON of communities or areas.
 
      Args:
-         curr_route - Current route ex. /taspr/huc/
+         curr_route - Current route ex. /taspr/area/
          curr_type - Either community or area.
          place - One community or area from the API response.
          cache_url - The base URL for the API cache, e.g., https://earthmaps.io

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -2,8 +2,6 @@ import requests
 from prefect import task
 from luts import eds_cached_url, ncr_cached_urls
 
-CACHE_HOSTNAME = "https://earthmaps.io"
-
 
 @task(name="Recache API")
 def recache_api(cached_apps, cache_url):

--- a/recache_api/recache_tasks.py
+++ b/recache_api/recache_tasks.py
@@ -5,9 +5,9 @@ from luts import eds_cached_url, ncr_cached_urls
 
 # Helper: get the list of places to construct URLs for various endpoints,
 # throw an error if there was a problem
-def get_places(places_url): 
+def get_places(places_url):
     response = requests.get(places_url)
-    if(response.status_code == 200):
+    if response.status_code == 200:
         return response.json()
     else:
         # Everything is hopeless, run away
@@ -15,7 +15,7 @@ def get_places(places_url):
 
 
 # Helper, return true if place type (community, area) matches route type (community, area).
-def route_type_matches_place_type(route_type, place)
+def route_type_matches_place_type(route_type, place):
     # If the route needs a community, skip if the place isn't a community
     if route_type == "community" and place["type"] != "community":
         return False
@@ -40,11 +40,11 @@ def recache_api(cached_apps, cache_url):
 
     """
     if "eds" in cached_apps:
-        recache_eds()
+        recache_eds(cache_url)
 
     if "ncr" in cached_apps:
-        recache_ncr()
- 
+        recache_ncr(cache_url)
+
 
 def recache_eds(cache_url):
     # Fetch the list of places to cache: all Alaska communities
@@ -54,7 +54,7 @@ def recache_eds(cache_url):
 
 def recache_ncr(cache_url):
     places_url = cache_url + "/places/all?tags=ncr"
-    places = get_places(places_url) # has both communities (points) and areas
+    places = get_places(places_url)  # has both communities (points) and areas
 
     # Iterate over the list of URLs that need to be cached
     for route, route_type in ncr_cached_urls.items():
@@ -66,7 +66,7 @@ def recache_ncr(cache_url):
 # This is because some endpoints can only take areas or points.
 def get_matching_endpoints(places, route, route_type, cache_url):
     for place in places:
-        if(route_type_matches_place_type(route_type, place)):
+        if route_type_matches_place_type(route_type, place):
             get_endpoint(route, place, route_type, cache_url)
 
 
@@ -86,13 +86,7 @@ def get_endpoint(route, place, route_type, cache_url):
     """
     # Build the URL to query based on type
     if route_type == "community":
-        url = (
-            cache_url
-            + route
-            + str(place["latitude"])
-            + "/"
-            + str(place["longitude"])
-        )
+        url = cache_url + route + str(place["latitude"]) + "/" + str(place["longitude"])
     else:
         url = cache_url + route + str(place["id"])
 


### PR DESCRIPTION
This PR is a rewrite of the recaching flow such that all endpoints for a given application are cached together rather than individual endpoints that are given to the recaching workflow. This code also utilizes the /places endpoint of the API to gather the places to be cached, rather than an explicit WFS call to Geoserver. Additionally, this adds the ability to specify the API's cache URL for cases where we need to cache an API other than our production API.