### PR TITLE
Makes the Sea Ice Concentration end date endpoint always be non-cached for the Varnish configuration.

### DIFF
--- a/recache_api/varnish.vcl
+++ b/recache_api/varnish.vcl
@@ -44,7 +44,7 @@ sub vcl_recv {
         return (pass);
     }
 
-    if (req.url ~ "^/seaice/enddate/) {
+    if (req.url ~ "^/seaice/enddate/") {
         return (pass);
     }
 }


### PR DESCRIPTION
This PR updates the Varnish configuration to always send a passthrough to the backend API for any requests that go to /seaice/enddate/. This will prevent stale end dates for the Sea Ice Concentration data when we update it in the future.