### PR TITLE
WRF-Downscaled ERA5 4km Flows

### DIFF
--- a/era5_4km/README.md
+++ b/era5_4km/README.md
@@ -1,0 +1,35 @@
+# WRF-Downscaled ERA5 4km Data Curation Flows
+
+This directory contains Prefect flows for processing and archiving ERA5 downscaled data.
+
+## Workflow Overview
+
+### Processing Flow (`curate_era5_4km.py`)
+- **Purpose**: Orchestrate ERA5 data processing on Chinook
+- **Output**: Processed ERA5 data in specified directories
+
+### Archival Flow (`archive_era5.py`)  
+- **Purpose**: Archive completed data to Poseidon storage
+- **Output**: Compressed archives on Poseidon
+
+## Usage
+Start a local Prefect server, something like:
+```sh
+prefect config set PREFECT_API_URL=http://127.0.0.1:4200/api
+prefect server start
+```
+Once the server is running, serve the flow(s):
+```sh
+python curate_era5_4km.py
+```
+or
+```sh
+python archive_era5_simple.py
+```
+or, to serve both flows at once:
+```sh
+python curate_era5_4km.py & python archive_era5_simple.py &
+```
+
+## Reports
+Both flows generate Prefect artifacts that can be examined in the Artifact tab of the Prefect UI.

--- a/era5_4km/README.md
+++ b/era5_4km/README.md
@@ -18,6 +18,13 @@ Start a local Prefect server, something like:
 prefect config set PREFECT_API_URL=http://127.0.0.1:4200/api
 prefect server start
 ```
+
+When developing these flows, Prefect yelled about not being able to cache some objects (like SSH connections, which makes sense) - and while these warnings didn't prohibit successful execution, they were annoying and made it hard for me to read the logs so I squashed them like this, and you will likely want to do the same:
+
+```sh
+ export PREFECT_TASKS_DEFAULT_NO_CACHE=true
+ ```
+
 Once the server is running, serve the flow(s):
 ```sh
 python curate_era5_4km.py

--- a/era5_4km/README.md
+++ b/era5_4km/README.md
@@ -1,4 +1,4 @@
-# WRF-Downscaled ERA5 4km Data Curation Flows
+# WRF-Downscaled ERA5 4km Flows
 
 This directory contains Prefect flows for processing and archiving ERA5 downscaled data.
 
@@ -24,12 +24,18 @@ python curate_era5_4km.py
 ```
 or
 ```sh
-python archive_era5_simple.py
+python archive_era5.py
 ```
 or, to serve both flows at once:
 ```sh
-python curate_era5_4km.py & python archive_era5_simple.py &
+python curate_era5_4km.py & python archive_era5.py &
+```
+
+### SSH Agent Forwarding
+The archival flow requires SSH access to both Chinook and Poseidon - what I've been doing on my laptop is to ensure that the SSH agent is running and loaded with my key:
+```sh
+ssh-add ~/.ssh/id_rsa
 ```
 
 ## Reports
-Both flows generate Prefect artifacts that can be examined in the Artifact tab of the Prefect UI.
+Both flows generate Prefect artifact objects that can be examined in the "Artifact" tab of the Prefect UI.

--- a/era5_4km/archive_era5.py
+++ b/era5_4km/archive_era5.py
@@ -45,7 +45,9 @@ def discover_available_variables(ssh, source_directory: Path) -> list:
 
     # CP note: list subdirectories - some assumptions made re depth and naming, but I'm good with it
     cmd = f"find '{source_dir}' -maxdepth 1 -type d -exec basename {{}} \\; | grep -v '^curated_wrf_era5-04km$' | sort"
-    stdout, _ = curation_functions.execute_ssh_with_logging(ssh, cmd, "List variable directories")
+    stdout, _ = curation_functions.execute_ssh_with_logging(
+        ssh, cmd, "List variable directories"
+    )
 
     if not stdout:
         return []
@@ -165,30 +167,43 @@ def archive_single_variable(
 
         # Step 2: Remove any existing tar file to avoid conflicts
         logger.info("🧹 Cleaning up any existing archive...")
-        curation_functions.execute_ssh_with_logging(ssh, f"rm -f '{tar_path}'", "Remove existing tar file")
+        curation_functions.execute_ssh_with_logging(
+            ssh, f"rm -f '{tar_path}'", "Remove existing tar file"
+        )
 
         # Step 3: Create tar archive
         logger.info(f"📦 Creating archive: {tar_filename}")
         cmd = f"cd '{source_dir}' && tar -czf '{tar_filename}' '{variable_name}/'"
-        curation_functions.execute_ssh_with_logging(ssh, cmd, f"Create tar archive for {variable_name}")
+        curation_functions.execute_ssh_with_logging(
+            ssh, cmd, f"Create tar archive for {variable_name}"
+        )
 
         # Step 4: Verify archive was created and get size
         curation_functions.execute_ssh_with_logging(
             ssh, f"test -f '{tar_path}'", "Verify tar file was created"
         )
         size_cmd = f"ls -lh '{tar_path}' | awk '{{print $5}}'"
-        archive_size, _ = curation_functions.execute_ssh_with_logging(ssh, size_cmd, "Get archive size")
+        archive_size, _ = curation_functions.execute_ssh_with_logging(
+            ssh, size_cmd, "Get archive size"
+        )
         logger.info(f"📦 Archive created: {archive_size.strip()}")
 
         # Step 5: Create destination directory on Poseidon
         logger.info("📁 Creating destination directory on Poseidon...")
         cmd = f"ssh {ssh_username}@poseidon.snap.uaf.edu 'mkdir -p \"{dest_var_dir}\"'"
-        curation_functions.execute_ssh_with_logging(ssh, cmd, "Create destination directory on Poseidon", use_agent_forwarding=True)
+        curation_functions.execute_ssh_with_logging(
+            ssh,
+            cmd,
+            "Create destination directory on Poseidon",
+            use_agent_forwarding=True,
+        )
 
         # Step 6: Transfer archive to Poseidon
         logger.info("📤 Transferring archive to Poseidon...")
         cmd = f"scp '{tar_path}' {ssh_username}@poseidon.snap.uaf.edu:'{dest_var_dir}/'"
-        curation_functions.execute_ssh_with_logging(ssh, cmd, "Transfer archive to Poseidon", use_agent_forwarding=True)
+        curation_functions.execute_ssh_with_logging(
+            ssh, cmd, "Transfer archive to Poseidon", use_agent_forwarding=True
+        )
 
         # Step 7: Verify transfer completed
         logger.info("✅ Verifying transfer...")

--- a/era5_4km/archive_era5_simple.py
+++ b/era5_4km/archive_era5_simple.py
@@ -1,0 +1,558 @@
+from pathlib import Path
+import paramiko
+from prefect import flow, task, get_run_logger
+from prefect.artifacts import create_markdown_artifact
+from datetime import datetime
+import os
+
+# SSH connection details for Chinook HPC
+SSH_HOST = "chinook04.rcs.alaska.edu"
+SSH_PORT = 22
+
+"""
+Simple ERA5 Data Archival Flow
+
+This flow provides simple, reliable archival of completed ERA5 data to Poseidon storage.
+
+DESIGN PHILOSOPHY:
+==================
+
+- **Simplicity First**: Uses straightforward tar + scp commands
+- **Manual Control**: User decides when processing is complete  
+- **Zero Coupling**: Completely independent from main processing flow
+- **Selective Archiving**: Archive specific variables or all available
+- **Fail-Fast**: Clear error handling without complex retry logic
+
+USAGE:
+======
+
+# Archive specific variables after processing completes
+python archive_era5_simple.py --variables "t2_mean,t2_min,t2_max"
+
+# Archive all available variables  
+python archive_era5_simple.py --variables "all"
+
+# Archive with custom paths
+archive_era5_simple(
+    source_directory="/beegfs/CMIP6/snapdata/curated_wrf_era5-04km",
+    destination_directory="/workspace/Shared/Tech_Projects/daily_wrf_downscaled_era5_4km",
+    variables="t2_mean"
+)
+
+PROCESS:
+========
+
+1. Discover available variable directories in source location
+2. Create simple tar.gz archives on Chinook using basic tar command
+3. Transfer directly to Poseidon via scp
+4. Verify files exist on destination
+5. Optional cleanup of source archives
+6. Generate simple completion report
+
+BENEFITS:
+=========
+
+- No race conditions (manual timing control)
+- Simple to understand and debug
+- Independent execution
+- Fast and reliable for completed data
+"""
+
+
+def execute_ssh_with_logging(ssh: paramiko.SSHClient, command: str, description: str, remote_name: str = "chinook"):
+    """Execute a single SSH command with logging, with agent forwarding."""
+    logger = get_run_logger()
+    logger.info(f"[{remote_name}] {description}")
+    logger.debug(f"{remote_name} CMD: {command}")
+
+    # Open a new channel for the session from the existing transport
+    channel = ssh.get_transport().open_session()
+    
+    # Set up the agent request handler to handle agent requests from the server
+    paramiko.agent.AgentRequestHandler(channel)
+    
+    # Execute the command on the channel
+    channel.exec_command(command)
+    
+    # Read output, error, and exit status from the channel
+    exit_status = channel.recv_exit_status()
+    out = channel.makefile("r", -1).read().decode("utf-8").strip()
+    err = channel.makefile_stderr("r", -1).read().decode("utf-8").strip()
+
+    if exit_status != 0:
+        msg = f"SSH command failed – {description} (exit {exit_status})\nCMD: {command}"
+        if err:
+            msg += f"\nSTDERR: {err}"
+        if out:
+            msg += f"\nSTDOUT: {out}"
+        raise Exception(msg)
+
+    if out:
+        logger.debug(f"{remote_name} output: {out}")
+
+    return out, err
+
+
+@task
+def discover_available_variables(ssh, source_directory: Path) -> list:
+    """
+    Find all variable directories available for archiving
+    
+    Args:
+        ssh: Paramiko SSHClient connected to Chinook
+        source_directory: Path to ERA5 output directory
+        
+    Returns:
+        list: Variable names that have directories with data
+    """
+    logger = get_run_logger()
+    source_dir = str(source_directory)
+    
+    logger.info(f"Discovering available variables in {source_dir}")
+    
+    # List subdirectories
+    cmd = f"find '{source_dir}' -maxdepth 1 -type d -exec basename {{}} \\; | grep -v '^curated_wrf_era5-04km$' | sort"
+    stdout, _ = execute_ssh_with_logging(ssh, cmd, "List variable directories")
+    
+    if not stdout:
+        return []
+    
+    potential_vars = [line.strip() for line in stdout.split('\n') if line.strip()]
+    
+    # Verify each directory has data files
+    verified_vars = []
+    for var in potential_vars:
+        var_path = f"{source_dir}/{var}"
+        check_cmd = f"find '{var_path}' -name '*.nc' | head -1"
+        
+        try:
+            file_check, _ = execute_ssh_with_logging(ssh, check_cmd, f"Check for data in {var}")
+            if file_check:  # Found at least one .nc file
+                verified_vars.append(var)
+                logger.info(f"✅ {var}: Contains data files")
+            else:
+                logger.warning(f"⚠️ {var}: Directory exists but no .nc files found")
+        except Exception as e:
+            logger.warning(f"⚠️ {var}: Could not verify data files - {e}")
+    
+    logger.info(f"Found {len(verified_vars)} variables with data: {verified_vars}")
+    return verified_vars
+
+
+@task
+def estimate_archive_size(ssh, source_directory: Path, variable_name: str) -> dict:
+    """
+    Estimate the size of archive that will be created
+    
+    Args:
+        ssh: Paramiko SSHClient connected to Chinook
+        source_directory: Path to ERA5 output directory
+        variable_name: Variable to estimate
+        
+    Returns:
+        dict: Size information
+    """
+    logger = get_run_logger()
+    var_path = f"{source_directory}/{variable_name}"
+    
+    try:
+        # Get directory size
+        cmd = f"du -sh '{var_path}' | cut -f1"
+        size_str, _ = execute_ssh_with_logging(ssh, cmd, f"Get size for {variable_name}")
+        
+        # Count files
+        cmd = f"find '{var_path}' -name '*.nc' | wc -l"
+        file_count, _ = execute_ssh_with_logging(ssh, cmd, f"Count files for {variable_name}")
+        
+        return {
+            "variable": variable_name,
+            "size": size_str.strip(),
+            "file_count": int(file_count.strip())
+        }
+    except Exception as e:
+        logger.warning(f"Could not estimate size for {variable_name}: {e}")
+        return {
+            "variable": variable_name,
+            "size": "unknown",
+            "file_count": 0
+        }
+
+
+@task
+def archive_single_variable_simple(
+    ssh, 
+    source_directory: Path, 
+    variable_name: str, 
+    destination_directory: Path,
+    ssh_username: str,
+    cleanup_source_archive: bool = True
+) -> dict:
+    """
+    Archive one variable using the simplest possible approach
+    
+    Args:
+        ssh: Paramiko SSHClient connected to Chinook
+        source_directory: Path to ERA5 output directory on Chinook
+        variable_name: Variable to archive (e.g., 't2_mean')
+        destination_directory: Path to backup storage on Poseidon
+        ssh_username: Username for SSH connections
+        cleanup_source_archive: Whether to remove tar file from Chinook after transfer
+        
+    Returns:
+        dict: Archive result information
+    """
+    logger = get_run_logger()
+    
+    source_dir = str(source_directory)
+    dest_dir = str(destination_directory)
+    
+    var_path = f"{source_dir}/{variable_name}"
+    tar_filename = f"{variable_name}_era5_4km_archive.tar.gz"
+    tar_path = f"{source_dir}/{tar_filename}"
+    dest_var_dir = f"{dest_dir}/{variable_name}"
+    dest_tar_path = f"{dest_var_dir}/{tar_filename}"
+    
+    logger.info(f"🗜️ Starting simple archive for variable: {variable_name}")
+    
+    start_time = datetime.now()
+    
+    try:
+        # Step 1: Validate source directory exists and has content
+        logger.info("📋 Validating source directory...")
+        execute_ssh_with_logging(ssh, f"test -d '{var_path}'", f"Verify {variable_name} directory exists")
+        execute_ssh_with_logging(ssh, f"test \"$(ls -A '{var_path}' 2>/dev/null)\"", f"Verify {variable_name} has content")
+        
+        # Step 2: Remove any existing tar file to avoid conflicts
+        logger.info("🧹 Cleaning up any existing archive...")
+        execute_ssh_with_logging(ssh, f"rm -f '{tar_path}'", "Remove existing tar file")
+        
+        # Step 3: Create tar archive using simple command
+        logger.info(f"📦 Creating archive: {tar_filename}")
+        cmd = f"cd '{source_dir}' && tar -czf '{tar_filename}' '{variable_name}/'"
+        execute_ssh_with_logging(ssh, cmd, f"Create tar archive for {variable_name}")
+        
+        # Step 4: Verify archive was created and get size
+        execute_ssh_with_logging(ssh, f"test -f '{tar_path}'", "Verify tar file was created")
+        size_cmd = f"ls -lh '{tar_path}' | awk '{{print $5}}'"
+        archive_size, _ = execute_ssh_with_logging(ssh, size_cmd, "Get archive size")
+        logger.info(f"📦 Archive created: {archive_size.strip()}")
+        
+        # Step 5: Create destination directory on Poseidon
+        logger.info("📁 Creating destination directory on Poseidon...")
+        cmd = f"ssh {ssh_username}@poseidon.snap.uaf.edu 'mkdir -p \"{dest_var_dir}\"'"
+        execute_ssh_with_logging(ssh, cmd, "Create destination directory on Poseidon")
+        
+        # Step 6: Transfer archive to Poseidon
+        logger.info("📤 Transferring archive to Poseidon...")
+        cmd = f"scp '{tar_path}' {ssh_username}@poseidon.snap.uaf.edu:'{dest_var_dir}/'"
+        execute_ssh_with_logging(ssh, cmd, "Transfer archive to Poseidon")
+        
+        # Step 7: Verify transfer completed
+        logger.info("✅ Verifying transfer...")
+        cmd = f"ssh {ssh_username}@poseidon.snap.uaf.edu 'test -f \"{dest_tar_path}\" && ls -lh \"{dest_tar_path}\" | awk \"{{print \\$5}}\"'"
+        remote_size, _ = execute_ssh_with_logging(ssh, cmd, "Verify file exists on Poseidon")
+        
+        if not remote_size:
+            raise Exception("Archive file not found on Poseidon after transfer")
+        
+        logger.info(f"✅ Verified on Poseidon: {remote_size.strip()}")
+        
+        # Step 8: Optional cleanup
+        if cleanup_source_archive:
+            logger.info("🧹 Cleaning up source archive...")
+            execute_ssh_with_logging(ssh, f"rm -f '{tar_path}'", "Remove source tar file")
+            logger.info("✅ Source archive cleaned up")
+        else:
+            logger.info("📦 Source archive preserved on Chinook")
+        
+        end_time = datetime.now()
+        duration = str(end_time - start_time)
+        
+        result = {
+            "variable": variable_name,
+            "status": "success",
+            "archive_size": archive_size.strip(),
+            "destination_path": dest_tar_path,
+            "duration": duration,
+            "start_time": start_time.strftime('%Y-%m-%d %H:%M:%S'),
+            "end_time": end_time.strftime('%Y-%m-%d %H:%M:%S'),
+            "cleanup_performed": cleanup_source_archive
+        }
+        
+        logger.info(f"✅ Successfully archived {variable_name} in {duration}")
+        return result
+        
+    except Exception as e:
+        end_time = datetime.now()
+        duration = str(end_time - start_time)
+        
+        logger.error(f"❌ Failed to archive {variable_name}: {str(e)}")
+        
+        # Attempt cleanup on failure
+        try:
+            execute_ssh_with_logging(ssh, f"rm -f '{tar_path}'", "Cleanup failed archive")
+        except:
+            pass  # Ignore cleanup failures
+        
+        return {
+            "variable": variable_name,
+            "status": "failed",
+            "error": str(e),
+            "duration": duration,
+            "start_time": start_time.strftime('%Y-%m-%d %H:%M:%S'),
+            "end_time": end_time.strftime('%Y-%m-%d %H:%M:%S')
+        }
+
+
+@task
+def create_simple_archive_report(results: dict, size_estimates: list) -> str:
+    """
+    Create a simple archival summary report
+    
+    Args:
+        results: Dictionary with 'success' and 'failed' lists
+        size_estimates: List of size estimation dictionaries
+        
+    Returns:
+        str: Artifact ID
+    """
+    logger = get_run_logger()
+    
+    success_count = len(results["success"])
+    failed_count = len(results["failed"])
+    total_count = success_count + failed_count
+    
+    # Determine status
+    if failed_count == 0:
+        status_icon = "✅"
+        status_text = "ALL SUCCESSFUL"
+    elif success_count == 0:
+        status_icon = "❌"
+        status_text = "ALL FAILED"
+    else:
+        status_icon = "⚠️"
+        status_text = "PARTIAL SUCCESS"
+    
+    # Build success section
+    success_section = ""
+    if results["success"]:
+        for item in results["success"]:
+            success_section += f"- **{item['variable']}**: {item['archive_size']} → `{item['destination_path']}` (took {item['duration']})\n"
+    else:
+        success_section = "*No variables were successfully archived*\n"
+    
+    # Build failure section
+    failure_section = ""
+    if results["failed"]:
+        for item in results["failed"]:
+            failure_section += f"- **{item['variable']}**: {item['error']} (failed after {item['duration']})\n"
+    else:
+        failure_section = "*No archival failures*\n"
+    
+    # Build size estimates section
+    estimates_section = ""
+    if size_estimates:
+        for est in size_estimates:
+            estimates_section += f"- **{est['variable']}**: {est['size']} ({est['file_count']} files)\n"
+    
+    # Calculate total duration
+    if results["success"] or results["failed"]:
+        all_items = results["success"] + results["failed"]
+        start_times = [datetime.strptime(item['start_time'], '%Y-%m-%d %H:%M:%S') for item in all_items]
+        end_times = [datetime.strptime(item['end_time'], '%Y-%m-%d %H:%M:%S') for item in all_items]
+        
+        total_start = min(start_times)
+        total_end = max(end_times)
+        total_duration = str(total_end - total_start)
+    else:
+        total_duration = "N/A"
+    
+    # Generate report
+    markdown_content = f"""# 📦 Simple ERA5 Archival Report
+
+**Status**: {status_icon} {status_text}  
+**Completed**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}  
+**Total Duration**: {total_duration}
+
+## 📊 Summary
+
+| Metric | Value |
+|--------|-------|
+| **Variables Processed** | {total_count} |
+| **Successfully Archived** | {success_count} |
+| **Failed Archives** | {failed_count} |
+| **Success Rate** | {(success_count/total_count*100):.1f}% if {total_count} > 0 else 0% |
+
+## 📏 Size Estimates
+
+{estimates_section}
+
+## ✅ Successfully Archived
+
+{success_section}
+
+## ❌ Failed Archives
+
+{failure_section}
+
+## 📋 Next Steps
+
+"""
+    
+    if failed_count > 0:
+        markdown_content += """
+### 🔧 For Failed Archives:
+1. Check error messages above for specific issues
+2. Verify network connectivity to Poseidon
+3. Ensure sufficient disk space on both systems
+4. Re-run archival for failed variables: `--variables "failed_var_name"`
+
+"""
+    
+    if success_count > 0:
+        markdown_content += """
+### ✅ Successful Archives:
+1. Verify archive integrity at destination if needed
+2. Archives are ready for use on Poseidon
+3. Source data remains available on Chinook (unless cleanup was enabled)
+
+"""
+    
+    markdown_content += """
+---
+*Report generated by Simple ERA5 Archival Flow*
+"""
+    
+    artifact_id = create_markdown_artifact(markdown_content)
+    logger.info(f"Created archival report artifact: {artifact_id}")
+    
+    return artifact_id
+
+
+@flow(name="era5-simple-archival", description="Simple ERA5 data archival to Poseidon")
+def archive_era5_simple(
+    ssh_username: str,
+    source_directory: Path,           # e.g., "/beegfs/CMIP6/snapdata/curated_wrf_era5-04km"
+    destination_directory: Path,      # e.g., "/workspace/Shared/Tech_Projects/daily_wrf_downscaled_era5_4km"
+    variables: str = "all",           # e.g., "t2_mean,t2_min,t2_max" or "all"
+    cleanup_source_archives: bool = True  # Remove tar files from Chinook after transfer
+):
+    """
+    Simple archival flow for ERA5 data
+    
+    Assumes processing is already complete - no synchronization logic needed
+    
+    Args:
+        ssh_username: Username for SSH connections to both Chinook and Poseidon
+        source_directory: Directory containing ERA5 variable subdirectories on Chinook
+        destination_directory: Target directory on Poseidon for archives
+        variables: Comma-separated variable names or "all" for everything available
+        cleanup_source_archives: Whether to remove tar files from Chinook after successful transfer
+    """
+    logger = get_run_logger()
+    
+    logger.info("🚀 Starting Simple ERA5 Archival Flow")
+    logger.info(f"Source: {source_directory}")
+    logger.info(f"Destination: {destination_directory}")
+    logger.info(f"Variables: {variables}")
+    
+    # Create SSH connection to Chinook
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    
+    try:
+        # Connect to Chinook using local SSH agent
+        logger.info("🔗 Connecting to Chinook HPC using SSH Agent...")
+        ssh.connect(SSH_HOST, SSH_PORT, username=ssh_username)
+        logger.info("✅ Connected to Chinook")
+        
+        # Step 1: Discover available variables
+        logger.info("🔍 Discovering available variables...")
+        available_vars = discover_available_variables(ssh, source_directory)
+        
+        if not available_vars:
+            logger.warning("⚠️ No variables with data found in source directory")
+            return {"success": [], "failed": [], "message": "No data found"}
+        
+        # Step 2: Parse requested variables
+        if variables.lower() == "all":
+            target_vars = available_vars
+            logger.info(f"📋 Will archive ALL {len(target_vars)} available variables")
+        else:
+            target_vars = [v.strip() for v in variables.split(',') if v.strip()]
+            logger.info(f"📋 Will archive {len(target_vars)} requested variables: {target_vars}")
+            
+            # Validate requested variables exist
+            missing_vars = [v for v in target_vars if v not in available_vars]
+            if missing_vars:
+                logger.error(f"❌ Requested variables not found: {missing_vars}")
+                logger.info(f"Available variables: {available_vars}")
+                raise Exception(f"Variables not found: {missing_vars}")
+        
+        # Step 3: Get size estimates
+        logger.info("📏 Estimating archive sizes...")
+        size_estimates = []
+        for var in target_vars:
+            estimate = estimate_archive_size(ssh, source_directory, var)
+            size_estimates.append(estimate)
+            logger.info(f"📦 {var}: ~{estimate['size']} ({estimate['file_count']} files)")
+        
+        # Step 4: Archive each variable
+        logger.info(f"🗜️ Starting archival of {len(target_vars)} variables...")
+        results = {"success": [], "failed": []}
+        
+        for i, var in enumerate(target_vars, 1):
+            logger.info(f"📦 Processing variable {i}/{len(target_vars)}: {var}")
+            
+            result = archive_single_variable_simple(
+                ssh, source_directory, var, destination_directory, ssh_username, cleanup_source_archives
+            )
+            
+            if result["status"] == "success":
+                results["success"].append(result)
+            else:
+                results["failed"].append(result)
+        
+        # Step 5: Generate report
+        logger.info("📋 Generating archival report...")
+        report_id = create_simple_archive_report(results, size_estimates)
+        
+        # Final summary
+        success_count = len(results["success"])
+        failed_count = len(results["failed"])
+        
+        if failed_count == 0:
+            logger.info(f"🎉 Archival completed successfully! All {success_count} variables archived.")
+        elif success_count == 0:
+            logger.error(f"❌ Archival failed completely! All {failed_count} variables failed.")
+        else:
+            logger.warning(f"⚠️ Partial success: {success_count} succeeded, {failed_count} failed.")
+        
+        logger.info(f"📋 Detailed report available in artifact: {report_id}")
+        
+        return {
+            "success": results["success"],
+            "failed": results["failed"],
+            "report_artifact_id": report_id,
+            "summary": f"{success_count}/{success_count + failed_count} successful"
+        }
+        
+    except Exception as e:
+        logger.error(f"❌ Archival flow failed: {str(e)}")
+        raise
+    finally:
+        ssh.close()
+        logger.info("🔗 SSH connection closed")
+
+
+if __name__ == "__main__":
+    archive_era5_simple.serve(
+        name="era5-simple-archive-deployment",
+        parameters={
+            "ssh_username": "snapdata",
+            "source_directory": Path("/beegfs/CMIP6/snapdata/curated_wrf_era5-04km"),
+            "destination_directory": Path("/workspace/Shared/Tech_Projects/daily_wrf_downscaled_era5_4km"),
+            "variables": "t2_mean,t2_min,t2_max",  # or "all"
+            "cleanup_source_archives": True
+        }
+    ) 

--- a/era5_4km/curate_era5_4km.py
+++ b/era5_4km/curate_era5_4km.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+import paramiko
+from prefect import flow, task, get_run_logger
+
+import curation_functions
+
+
+# SSH connection details for Chinook HPC
+SSH_HOST = "chinook04.rcs.alaska.edu"
+SSH_PORT = 22
+
+
+@flow(name="era5-processing",
+      description="Orchestrate ERA5 data processing on Chinook HPC",
+      log_prints=True)
+def submit_era5_jobs(
+    ssh_username: str,
+    ssh_private_key_path: Path,
+    branch_name: str,
+    working_directory: Path,
+    variables: str,
+    ERA5_INPUT_DIR: Path,
+    ERA5_OUTPUT_DIR: Path,
+    start_year: int,
+    end_year: int,
+    max_concurrent: int,
+    overwrite: bool = False,
+    no_retry: bool = False
+):
+    logger = get_run_logger()
+
+    # Create an SSH client
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    try:
+        # Load the private key for key-based authentication
+        private_key = paramiko.RSAKey(filename=ssh_private_key_path)
+        # Connect to the SSH server using key-based authentication
+        ssh.connect(SSH_HOST, SSH_PORT, ssh_username, pkey=private_key)
+
+        curation_functions.clone_github_repository(ssh, branch_name, working_directory)
+
+        curation_functions.check_for_nfs_mount(ssh, "/import/beegfs")
+
+        curation_functions.install_conda_environment(
+            ssh, "snap-geo", f"{working_directory}/wrf-downscaled-era5-curation/environment.yml"
+        )
+
+        repo_path = working_directory / "wrf-downscaled-era5-curation"
+        
+        @task
+        def build_and_run_job_submission_script():
+            cmd = (
+                f"export ERA5_INPUT_DIR={ERA5_INPUT_DIR} && "
+                f"export ERA5_OUTPUT_DIR={ERA5_OUTPUT_DIR} && "
+                f"conda activate snap-geo && "
+                f"cd {repo_path} && "
+                f"python submit_era5_jobs.py "
+                f"--variables {variables} "
+                f"--start_year {start_year} "
+                f"--end_year {end_year} "
+                f"--max_concurrent {max_concurrent} "
+            )
+    
+            if overwrite:
+                cmd += "--overwrite "
+            if no_retry:
+                cmd += "--no_retry"
+    
+            logger.info(f"Executing submission command: {cmd}")
+
+            stdin, stdout, stderr = ssh.exec_command(cmd)
+            exit_status = stdout.channel.recv_exit_status()
+            if exit_status != 0:
+                error_output = stderr.read().decode("utf-8")
+                raise Exception(f"Error submitting jobs: {error_output}")
+            else:
+                logger.info("Jobs submitted successfully")
+
+        build_and_run_job_submission_script()
+
+    except Exception as e:
+        logger.error(f"Flow failed: {str(e)}")
+        raise
+    finally:
+        ssh.close()
+        logger.info("SSH connection closed")
+
+if __name__ == "__main__":
+    submit_era5_jobs.serve(
+        parameters={
+            "ssh_username": "snapdata",
+            "ssh_private_key_path": "/Users/cparr/.ssh/id_rsa",
+            "branch_name": "batch_io",
+            "working_directory": Path("/beegfs/CMIP6/snapdata"),
+            "variables": "t2_mean,t2_min,t2_max",
+            "ERA5_INPUT_DIR": Path("/beegfs/CMIP6/wrf_era5/04km"),
+            "ERA5_OUTPUT_DIR": Path("/beegfs/CMIP6/snapdata/curated_wrf_era5-04km"),
+            "start_year": 1960,
+            "end_year": 2019,
+            "max_concurrent": 60,
+            "overwrite": False,
+            "no_retry": False,
+        }
+    )

--- a/era5_4km/curate_era5_4km.py
+++ b/era5_4km/curate_era5_4km.py
@@ -117,9 +117,9 @@ def submit_era5_jobs(
                     command=cmd,
                     description="Submit ERA5 processing jobs",
                     remote_name="chinook",
-                    use_agent_forwarding=False  # Standard execution for job submission
+                    use_agent_forwarding=False,  # Standard execution for job submission
                 )
-                
+
                 logger.info("Jobs submitted successfully")
                 # Capture full execution log
                 log_artifact_id = curation_functions.create_full_log_artifact(
@@ -132,12 +132,16 @@ def submit_era5_jobs(
             except Exception as e:
                 # Final attempt to capture any available logs
                 try:
-                    log_artifact_id = curation_functions.create_full_log_artifact(ssh, repo_path)
+                    log_artifact_id = curation_functions.create_full_log_artifact(
+                        ssh, repo_path
+                    )
                     logger.error(
                         f"Job submission failed. Full log captured in artifact: {log_artifact_id}"
                     )
                     # Re-raise with enhanced error message
-                    raise Exception(f"Error submitting jobs: {str(e)}\nLogs captured in artifact: {log_artifact_id}")
+                    raise Exception(
+                        f"Error submitting jobs: {str(e)}\nLogs captured in artifact: {log_artifact_id}"
+                    )
                 except:
                     logger.warning("Could not capture logs after error")
                     raise

--- a/era5_4km/curate_era5_4km.py
+++ b/era5_4km/curate_era5_4km.py
@@ -1,6 +1,5 @@
 """
-This flow orchestrates ERA5 data processing on Chinook
-For archiving completed data, use the separate `archive_era5_simple.py` flow.
+Orchestrate WRF-Downscaled ERA5 data processing on Chinook
 """
 
 from pathlib import Path
@@ -19,7 +18,7 @@ SSH_PORT = 22
 
 @flow(
     name="era5-processing",
-    description="Orchestrate ERA5 data processing on Chinook HPC",
+    description="Orchestrate ERA5 data processing on Chinook",
     log_prints=True,
 )
 def submit_era5_jobs(
@@ -55,12 +54,6 @@ def submit_era5_jobs(
 
     Returns:
         None: Flow completes when processing is finished
-
-    Artifacts:
-        Creates Prefect artifacts containing detailed execution logs and summaries
-
-    Next Steps:
-        After this flow completes, use archive_era5_simple() to archive the processed data
     """
     logger = get_run_logger()
 
@@ -170,7 +163,7 @@ def submit_era5_jobs(
 
         logger.info("✅ ERA5 processing completed successfully!")
         logger.info(
-            "💡 To archive the processed data, use the separate archive_era5_simple.py flow"
+            "To archive the processed data, use the separate archive_era5.py flow"
         )
         logger.info(f"📋 Processing logs captured in artifact: {log_artifact_id}")
 

--- a/era5_4km/curation_functions.py
+++ b/era5_4km/curation_functions.py
@@ -1,9 +1,13 @@
-from prefect import task, get_run_logger
-from prefect.artifacts import create_markdown_artifact
-import paramiko
+import os
+import re
+import tarfile
+import subprocess
 from pathlib import Path
 from datetime import datetime
-import re
+
+import paramiko
+from prefect import task, get_run_logger
+from prefect.artifacts import create_markdown_artifact
 
 
 @task
@@ -164,46 +168,68 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
 
 
 @task
+def tar_directory(directory, output_file):
+    with tarfile.open(output_file, "w:gz") as tar:
+        print("Creating new tar file of ERA5 data...")
+        for item in os.listdir(directory):
+            item_path = os.path.join(directory, item)
+            tar.add(item_path, arcname=item)
+    return output_file
+
+
+@task
+def copy_tarfile_to_storage_server(tar_file, target_directory):
+    print("Copying tar file to NFS server via scp...")
+    try:
+        subprocess.run(
+            ["scp", tar_file, f"poseidon.snap.uaf.edu:{target_directory}"], check=True
+        )
+        print(
+            f"File {tar_file} successfully copied to poseidon.snap.uaf.edu:{target_directory}"
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error copying file: {e}")
+
+
+@task
 def capture_remote_logs(ssh, repo_path: Path, log_file_path: str = None) -> dict:
     """
     Capture logs from remote HPC and create Prefect artifacts
-    
+
     Args:
         ssh: Paramiko SSHClient object
         repo_path: Path to the repository on remote system
         log_file_path: Optional custom log file path
-        
+
     Returns:
         dict: Status and artifact information with keys: status, content, artifact_id
     """
     logger = get_run_logger()
-    
+
     # Use default log path if not provided
     if log_file_path is None:
         log_file_path = f"{repo_path}/logs/submit_era5_jobs/submit_era5_jobs.log"
-    
+
     # Check if log file exists
-    stdin, stdout, stderr = ssh.exec_command(f"test -f {log_file_path} && echo 'exists' || echo 'missing'")
+    stdin, stdout, stderr = ssh.exec_command(
+        f"test -f {log_file_path} && echo 'exists' || echo 'missing'"
+    )
     file_status = stdout.read().decode("utf-8").strip()
-    
+
     if file_status == "missing":
         logger.warning(f"Log file not found at {log_file_path}")
-        return {
-            "status": "missing",
-            "content": "",
-            "artifact_id": None
-        }
-    
+        return {"status": "missing", "content": "", "artifact_id": None}
+
     # Retrieve log content
     stdin, stdout, stderr = ssh.exec_command(f"cat {log_file_path}")
     log_content = stdout.read().decode("utf-8")
-    
+
     logger.info(f"Retrieved {len(log_content)} characters from log file")
-    
+
     return {
         "status": "success",
         "content": log_content,
-        "artifact_id": None  # Will be set by calling function
+        "artifact_id": None,  # Will be set by calling function
     }
 
 
@@ -211,15 +237,15 @@ def capture_remote_logs(ssh, repo_path: Path, log_file_path: str = None) -> dict
 def parse_era5_log(log_content: str) -> dict:
     """
     Parse ERA5 log content to extract key metrics and statistics
-    
+
     Args:
         log_content: Raw log file content as string
-        
+
     Returns:
         dict: Parsed log data with key metrics
     """
     logger = get_run_logger()
-    
+
     try:
         # Initialize result dictionary
         parsed_data = {
@@ -230,89 +256,105 @@ def parse_era5_log(log_content: str) -> dict:
             "timing": {"start_time": None, "end_time": None, "duration": None},
             "retries": {"timeouts_detected": 0, "retries_attempted": 0},
             "completion_rate": 0.0,
-            "validation": {"expected_files": 0, "existing_files": 0, "missing_files": 0},
+            "validation": {
+                "expected_files": 0,
+                "existing_files": 0,
+                "missing_files": 0,
+            },
             "issues": [],
-            "raw_stats": {}
+            "raw_stats": {},
         }
-        
-        lines = log_content.split('\n')
-        
+
+        lines = log_content.split("\n")
+
         # Extract variables from job submissions
         variables_set = set()
         years_list = []
         job_count = 0
         timeout_jobs = []
         retry_count = 0
-        
+
         for line in lines:
             # Extract variables and years from job submissions
             if "Submitted job" in line and "for variable" in line:
                 job_count += 1
                 # Extract variable name
-                var_match = re.search(r'for variable (\w+), year (\d+)', line)
+                var_match = re.search(r"for variable (\w+), year (\d+)", line)
                 if var_match:
                     variables_set.add(var_match.group(1))
                     years_list.append(int(var_match.group(2)))
-            
+
             # Extract timeout information
             elif "Timeout detected for" in line:
-                timeout_match = re.search(r'Timeout detected for (\w+) year (\d+)', line)
+                timeout_match = re.search(
+                    r"Timeout detected for (\w+) year (\d+)", line
+                )
                 if timeout_match:
-                    timeout_jobs.append(f"{timeout_match.group(1)} {timeout_match.group(2)}")
+                    timeout_jobs.append(
+                        f"{timeout_match.group(1)} {timeout_match.group(2)}"
+                    )
                     parsed_data["retries"]["timeouts_detected"] += 1
-            
+
             # Extract retry job submissions
             elif "RETRY: Submitted job" in line:
                 retry_count += 1
                 parsed_data["retries"]["retries_attempted"] += 1
-            
+
             # Extract validation results
             elif "Expected files:" in line:
-                expected_match = re.search(r'Expected files: (\d+)', line)
+                expected_match = re.search(r"Expected files: (\d+)", line)
                 if expected_match:
-                    parsed_data["validation"]["expected_files"] = int(expected_match.group(1))
-            
+                    parsed_data["validation"]["expected_files"] = int(
+                        expected_match.group(1)
+                    )
+
             elif "Existing files:" in line:
-                existing_match = re.search(r'Existing files: (\d+)', line)
+                existing_match = re.search(r"Existing files: (\d+)", line)
                 if existing_match:
-                    parsed_data["validation"]["existing_files"] = int(existing_match.group(1))
-            
+                    parsed_data["validation"]["existing_files"] = int(
+                        existing_match.group(1)
+                    )
+
             elif "Missing files:" in line:
-                missing_match = re.search(r'Missing files: (\d+)', line)
+                missing_match = re.search(r"Missing files: (\d+)", line)
                 if missing_match:
-                    parsed_data["validation"]["missing_files"] = int(missing_match.group(1))
-            
+                    parsed_data["validation"]["missing_files"] = int(
+                        missing_match.group(1)
+                    )
+
             # Extract completion rate
             elif "Overall completion rate:" in line:
-                rate_match = re.search(r'Overall completion rate: ([\d.]+)%', line)
+                rate_match = re.search(r"Overall completion rate: ([\d.]+)%", line)
                 if rate_match:
                     parsed_data["completion_rate"] = float(rate_match.group(1))
-        
+
         # Process extracted data
         parsed_data["variables"] = sorted(list(variables_set))
         if years_list:
             parsed_data["years_processed"]["start"] = min(years_list)
             parsed_data["years_processed"]["end"] = max(years_list)
-        
+
         parsed_data["jobs"]["submitted"] = job_count + retry_count
-        parsed_data["jobs"]["completed"] = job_count + retry_count  # Assume all submitted jobs eventually complete
-        
+        parsed_data["jobs"]["completed"] = (
+            job_count + retry_count
+        )  # Assume all submitted jobs eventually complete
+
         # Extract timing information from first and last log entries
-        timestamp_pattern = r'(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})'
+        timestamp_pattern = r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"
         timestamps = re.findall(timestamp_pattern, log_content)
         if timestamps:
             parsed_data["timing"]["start_time"] = timestamps[0]
             parsed_data["timing"]["end_time"] = timestamps[-1]
-            
+
             # Calculate duration if we have both timestamps
             try:
-                start_dt = datetime.strptime(timestamps[0], '%Y-%m-%d %H:%M:%S')
-                end_dt = datetime.strptime(timestamps[-1], '%Y-%m-%d %H:%M:%S')
+                start_dt = datetime.strptime(timestamps[0], "%Y-%m-%d %H:%M:%S")
+                end_dt = datetime.strptime(timestamps[-1], "%Y-%m-%d %H:%M:%S")
                 duration = end_dt - start_dt
                 parsed_data["timing"]["duration"] = str(duration)
             except ValueError:
                 parsed_data["timing"]["duration"] = "Unable to calculate"
-        
+
         # Determine overall status
         if "All processing completed successfully" in log_content:
             parsed_data["status"] = "SUCCESS"
@@ -324,28 +366,36 @@ def parse_era5_log(log_content: str) -> dict:
             parsed_data["status"] = "COMPLETED WITH RETRIES"
         else:
             parsed_data["status"] = "UNKNOWN"
-        
+
         # Identify issues
         if parsed_data["retries"]["timeouts_detected"] > 0:
-            parsed_data["issues"].append(f"{parsed_data['retries']['timeouts_detected']} jobs timed out and required retries")
-        
+            parsed_data["issues"].append(
+                f"{parsed_data['retries']['timeouts_detected']} jobs timed out and required retries"
+            )
+
         if parsed_data["validation"]["missing_files"] > 0:
-            parsed_data["issues"].append(f"{parsed_data['validation']['missing_files']} expected output files are missing")
-        
+            parsed_data["issues"].append(
+                f"{parsed_data['validation']['missing_files']} expected output files are missing"
+            )
+
         if parsed_data["completion_rate"] < 100.0:
-            parsed_data["issues"].append(f"Completion rate is {parsed_data['completion_rate']}% (less than 100%)")
-        
-        logger.info(f"Successfully parsed log: {len(parsed_data['variables'])} variables, {parsed_data['jobs']['submitted']} jobs")
+            parsed_data["issues"].append(
+                f"Completion rate is {parsed_data['completion_rate']}% (less than 100%)"
+            )
+
+        logger.info(
+            f"Successfully parsed log: {len(parsed_data['variables'])} variables, {parsed_data['jobs']['submitted']} jobs"
+        )
         return parsed_data
-        
+
     except Exception as e:
         logger.warning(f"Error parsing log content: {str(e)}")
         return {
-            "status": "PARSE_ERROR", 
+            "status": "PARSE_ERROR",
             "error": str(e),
             "variables": [],
             "jobs": {"submitted": 0, "completed": 0},
-            "issues": [f"Log parsing failed: {str(e)}"]
+            "issues": [f"Log parsing failed: {str(e)}"],
         }
 
 
@@ -353,14 +403,14 @@ def parse_era5_log(log_content: str) -> dict:
 def generate_log_summary(parsed_data: dict) -> str:
     """
     Generate a formatted summary from parsed log data
-    
+
     Args:
         parsed_data: Dictionary containing parsed log metrics
-        
+
     Returns:
         str: Formatted markdown summary
     """
-    
+
     # Handle parse errors gracefully
     if parsed_data.get("status") == "PARSE_ERROR":
         return f"""## ⚠️ Log Parsing Error
@@ -371,10 +421,12 @@ def generate_log_summary(parsed_data: dict) -> str:
 
 ---
 """
-    
+
     # Build variables string
-    variables_str = ", ".join(parsed_data["variables"]) if parsed_data["variables"] else "Unknown"
-    
+    variables_str = (
+        ", ".join(parsed_data["variables"]) if parsed_data["variables"] else "Unknown"
+    )
+
     # Build year range string
     year_start = parsed_data["years_processed"].get("start")
     year_end = parsed_data["years_processed"].get("end")
@@ -385,24 +437,24 @@ def generate_log_summary(parsed_data: dict) -> str:
             years_str = f"{year_start} - {year_end}"
     else:
         years_str = "Unknown"
-    
+
     # Status emoji mapping
     status_emoji = {
         "SUCCESS": "✅",
         "PARTIAL SUCCESS": "⚠️",
         "COMPLETED WITH RETRIES": "🔄",
         "UNKNOWN": "❓",
-        "FAILED": "❌"
+        "FAILED": "❌",
     }
-    
+
     status_icon = status_emoji.get(parsed_data["status"], "❓")
-    
+
     # Build duration string
     duration = parsed_data["timing"].get("duration", "Unknown")
-    
+
     # Calculate success rate for display
     completion_rate = parsed_data.get("completion_rate", 0)
-    
+
     # Build summary
     summary = f"""## 📊 ERA5 Processing Executive Summary
 
@@ -422,12 +474,12 @@ def generate_log_summary(parsed_data: dict) -> str:
 | **Retries Required** | {parsed_data["retries"]["retries_attempted"]} jobs |
 | **Timeouts Detected** | {parsed_data["retries"]["timeouts_detected"]} jobs |
 """
-    
+
     # Add validation section if data available
     if parsed_data["validation"]["expected_files"] > 0:
         summary += f"""| **File Validation** | {parsed_data["validation"]["existing_files"]}/{parsed_data["validation"]["expected_files"]} files present |
 """
-    
+
     # Add timing details if available
     if parsed_data["timing"]["start_time"]:
         summary += f"""
@@ -438,7 +490,7 @@ def generate_log_summary(parsed_data: dict) -> str:
 | **Completed** | {parsed_data["timing"]["end_time"]} |
 | **Total Duration** | {duration} |
 """
-    
+
     # Add issues section if any exist
     if parsed_data["issues"]:
         summary += f"""
@@ -451,9 +503,9 @@ def generate_log_summary(parsed_data: dict) -> str:
 ### ✅ No Issues Detected
 All processing completed without warnings or errors.
 """
-    
+
     summary += "\n---\n"
-    
+
     return summary
 
 
@@ -461,9 +513,9 @@ All processing completed without warnings or errors.
 def create_full_log_artifact(ssh, repo_path: Path) -> str:
     """Create complete log file artifact with intelligent summary"""
     logger = get_run_logger()
-    
+
     log_result = capture_remote_logs(ssh, repo_path)
-    
+
     if log_result["status"] == "missing":
         markdown_content = f"""# 📝 ERA5 Full Log
 
@@ -475,7 +527,7 @@ No log file was found at the expected location.
 """
     else:
         log_content = log_result["content"]
-        
+
         # Parse log content and generate summary
         try:
             parsed_data = parse_era5_log(log_content)
@@ -489,12 +541,15 @@ Unable to generate automated summary: {str(e)}
 
 ---
 """
-        
+
         # Truncate extremely large logs for the full content section
         display_log_content = log_content
         if len(log_content) > 100000:  # 100KB limit for full log
-            display_log_content = log_content[:100000] + "\n\n... (log truncated - showing first 100KB) ..."
-        
+            display_log_content = (
+                log_content[:100000]
+                + "\n\n... (log truncated - showing first 100KB) ..."
+            )
+
         markdown_content = f"""# 📝 ERA5 Full Execution Log
 
 **Repository:** `{repo_path}`  
@@ -512,13 +567,7 @@ Unable to generate automated summary: {str(e)}
 ---
 *Complete log captured by ERA5 Curation Flow*
 """
-    
+
     artifact_id = create_markdown_artifact(markdown_content)
     logger.info(f"Created enhanced log artifact with summary: {artifact_id}")
     return artifact_id
-
-
-
-
-
-

--- a/era5_4km/curation_functions.py
+++ b/era5_4km/curation_functions.py
@@ -6,6 +6,7 @@ import paramiko
 from prefect import task, get_run_logger
 from prefect.artifacts import create_markdown_artifact
 
+
 @task
 def execute_ssh_with_logging(
     ssh: paramiko.SSHClient,
@@ -16,17 +17,17 @@ def execute_ssh_with_logging(
 ) -> tuple[str, str]:
     """
     Execute a single SSH command with logging and error handling.
-    
+
     Args:
         ssh: Paramiko SSHClient object
         command: Command to execute on remote system
         description: Human-readable description for logging
         remote_name: Name of remote system for logging context
         use_agent_forwarding: Whether to use SSH agent forwarding for multi-hop connections
-        
+
     Returns:
         tuple: (stdout, stderr) output from command execution
-        
+
     Raises:
         Exception: If command exits with non-zero status, includes full error context
     """
@@ -40,7 +41,7 @@ def execute_ssh_with_logging(
         channel = ssh.get_transport().open_session()
         paramiko.agent.AgentRequestHandler(channel)
         channel.exec_command(command)
-        
+
         exit_status = channel.recv_exit_status()
         out = channel.makefile("r", -1).read().decode("utf-8").strip()
         err = channel.makefile_stderr("r", -1).read().decode("utf-8").strip()
@@ -433,4 +434,3 @@ Unable to generate automated summary: {str(e)}
     artifact_id = create_markdown_artifact(markdown_content)
     logger.info(f"Created log artifact with summary: {artifact_id}")
     return artifact_id
-

--- a/era5_4km/curation_functions.py
+++ b/era5_4km/curation_functions.py
@@ -1,6 +1,9 @@
-from time import sleep
-from prefect import task
+from prefect import task, get_run_logger
+from prefect.artifacts import create_markdown_artifact
 import paramiko
+from pathlib import Path
+from datetime import datetime
+import re
 
 
 @task
@@ -160,82 +163,362 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
         print(f"Conda environment '{conda_env_name}' already exists.")
 
 
-# @task
-# def qc(ssh, working_dir, input_dir):
-#     """
-#     Task to run the quality control (QC) script to check the output of the indicator calculations.
+@task
+def capture_remote_logs(ssh, repo_path: Path, log_file_path: str = None) -> dict:
+    """
+    Capture logs from remote HPC and create Prefect artifacts
+    
+    Args:
+        ssh: Paramiko SSHClient object
+        repo_path: Path to the repository on remote system
+        log_file_path: Optional custom log file path
+        
+    Returns:
+        dict: Status and artifact information with keys: status, content, artifact_id
+    """
+    logger = get_run_logger()
+    
+    # Use default log path if not provided
+    if log_file_path is None:
+        log_file_path = f"{repo_path}/logs/submit_era5_jobs/submit_era5_jobs.log"
+    
+    # Check if log file exists
+    stdin, stdout, stderr = ssh.exec_command(f"test -f {log_file_path} && echo 'exists' || echo 'missing'")
+    file_status = stdout.read().decode("utf-8").strip()
+    
+    if file_status == "missing":
+        logger.warning(f"Log file not found at {log_file_path}")
+        return {
+            "status": "missing",
+            "content": "",
+            "artifact_id": None
+        }
+    
+    # Retrieve log content
+    stdin, stdout, stderr = ssh.exec_command(f"cat {log_file_path}")
+    log_content = stdout.read().decode("utf-8")
+    
+    logger.info(f"Retrieved {len(log_content)} characters from log file")
+    
+    return {
+        "status": "success",
+        "content": log_content,
+        "artifact_id": None  # Will be set by calling function
+    }
 
-#     Parameters:
-#     - ssh: Paramiko SSHClient object
-#     - working_dir: Directory to where all of the processing takes place
-#     """
 
-#     run_qc_script = f"{working_dir}/cmip6-utils/indicators/run_qc.py"
-#     qc_script = f"{working_dir}/cmip6-utils/indicators/qc.py"
-#     output_dir = f"{working_dir}/cmip6_indicators"
-#     slurm_dir = f"{working_dir}/cmip6_indicators/slurm"
+@task
+def parse_era5_log(log_content: str) -> dict:
+    """
+    Parse ERA5 log content to extract key metrics and statistics
+    
+    Args:
+        log_content: Raw log file content as string
+        
+    Returns:
+        dict: Parsed log data with key metrics
+    """
+    logger = get_run_logger()
+    
+    try:
+        # Initialize result dictionary
+        parsed_data = {
+            "status": "UNKNOWN",
+            "variables": [],
+            "years_processed": {"start": None, "end": None},
+            "jobs": {"submitted": 0, "completed": 0},
+            "timing": {"start_time": None, "end_time": None, "duration": None},
+            "retries": {"timeouts_detected": 0, "retries_attempted": 0},
+            "completion_rate": 0.0,
+            "validation": {"expected_files": 0, "existing_files": 0, "missing_files": 0},
+            "issues": [],
+            "raw_stats": {}
+        }
+        
+        lines = log_content.split('\n')
+        
+        # Extract variables from job submissions
+        variables_set = set()
+        years_list = []
+        job_count = 0
+        timeout_jobs = []
+        retry_count = 0
+        
+        for line in lines:
+            # Extract variables and years from job submissions
+            if "Submitted job" in line and "for variable" in line:
+                job_count += 1
+                # Extract variable name
+                var_match = re.search(r'for variable (\w+), year (\d+)', line)
+                if var_match:
+                    variables_set.add(var_match.group(1))
+                    years_list.append(int(var_match.group(2)))
+            
+            # Extract timeout information
+            elif "Timeout detected for" in line:
+                timeout_match = re.search(r'Timeout detected for (\w+) year (\d+)', line)
+                if timeout_match:
+                    timeout_jobs.append(f"{timeout_match.group(1)} {timeout_match.group(2)}")
+                    parsed_data["retries"]["timeouts_detected"] += 1
+            
+            # Extract retry job submissions
+            elif "RETRY: Submitted job" in line:
+                retry_count += 1
+                parsed_data["retries"]["retries_attempted"] += 1
+            
+            # Extract validation results
+            elif "Expected files:" in line:
+                expected_match = re.search(r'Expected files: (\d+)', line)
+                if expected_match:
+                    parsed_data["validation"]["expected_files"] = int(expected_match.group(1))
+            
+            elif "Existing files:" in line:
+                existing_match = re.search(r'Existing files: (\d+)', line)
+                if existing_match:
+                    parsed_data["validation"]["existing_files"] = int(existing_match.group(1))
+            
+            elif "Missing files:" in line:
+                missing_match = re.search(r'Missing files: (\d+)', line)
+                if missing_match:
+                    parsed_data["validation"]["missing_files"] = int(missing_match.group(1))
+            
+            # Extract completion rate
+            elif "Overall completion rate:" in line:
+                rate_match = re.search(r'Overall completion rate: ([\d.]+)%', line)
+                if rate_match:
+                    parsed_data["completion_rate"] = float(rate_match.group(1))
+        
+        # Process extracted data
+        parsed_data["variables"] = sorted(list(variables_set))
+        if years_list:
+            parsed_data["years_processed"]["start"] = min(years_list)
+            parsed_data["years_processed"]["end"] = max(years_list)
+        
+        parsed_data["jobs"]["submitted"] = job_count + retry_count
+        parsed_data["jobs"]["completed"] = job_count + retry_count  # Assume all submitted jobs eventually complete
+        
+        # Extract timing information from first and last log entries
+        timestamp_pattern = r'(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})'
+        timestamps = re.findall(timestamp_pattern, log_content)
+        if timestamps:
+            parsed_data["timing"]["start_time"] = timestamps[0]
+            parsed_data["timing"]["end_time"] = timestamps[-1]
+            
+            # Calculate duration if we have both timestamps
+            try:
+                start_dt = datetime.strptime(timestamps[0], '%Y-%m-%d %H:%M:%S')
+                end_dt = datetime.strptime(timestamps[-1], '%Y-%m-%d %H:%M:%S')
+                duration = end_dt - start_dt
+                parsed_data["timing"]["duration"] = str(duration)
+            except ValueError:
+                parsed_data["timing"]["duration"] = "Unable to calculate"
+        
+        # Determine overall status
+        if "All processing completed successfully" in log_content:
+            parsed_data["status"] = "SUCCESS"
+        elif parsed_data["completion_rate"] >= 100.0:
+            parsed_data["status"] = "SUCCESS"
+        elif parsed_data["completion_rate"] >= 90.0:
+            parsed_data["status"] = "PARTIAL SUCCESS"
+        elif parsed_data["retries"]["timeouts_detected"] > 0:
+            parsed_data["status"] = "COMPLETED WITH RETRIES"
+        else:
+            parsed_data["status"] = "UNKNOWN"
+        
+        # Identify issues
+        if parsed_data["retries"]["timeouts_detected"] > 0:
+            parsed_data["issues"].append(f"{parsed_data['retries']['timeouts_detected']} jobs timed out and required retries")
+        
+        if parsed_data["validation"]["missing_files"] > 0:
+            parsed_data["issues"].append(f"{parsed_data['validation']['missing_files']} expected output files are missing")
+        
+        if parsed_data["completion_rate"] < 100.0:
+            parsed_data["issues"].append(f"Completion rate is {parsed_data['completion_rate']}% (less than 100%)")
+        
+        logger.info(f"Successfully parsed log: {len(parsed_data['variables'])} variables, {parsed_data['jobs']['submitted']} jobs")
+        return parsed_data
+        
+    except Exception as e:
+        logger.warning(f"Error parsing log content: {str(e)}")
+        return {
+            "status": "PARSE_ERROR", 
+            "error": str(e),
+            "variables": [],
+            "jobs": {"submitted": 0, "completed": 0},
+            "issues": [f"Log parsing failed: {str(e)}"]
+        }
 
-#     stdin, stdout, stderr = ssh.exec_command(
-#         f"conda activate cmip6-utils\n"
-#         f"python {run_qc_script} \
-#             --qc_script '{qc_script}' \
-#             --in_dir '{input_dir}' \
-#             --out_dir '{output_dir}' \
-#             --slurm_dir '{slurm_dir}'"
-#     )
 
-#     # Wait for the command to finish and get the exit status
-#     exit_status = stdout.channel.recv_exit_status()
+@task
+def generate_log_summary(parsed_data: dict) -> str:
+    """
+    Generate a formatted summary from parsed log data
+    
+    Args:
+        parsed_data: Dictionary containing parsed log metrics
+        
+    Returns:
+        str: Formatted markdown summary
+    """
+    
+    # Handle parse errors gracefully
+    if parsed_data.get("status") == "PARSE_ERROR":
+        return f"""## ⚠️ Log Parsing Error
 
-#     # Check the exit status for errors
-#     if exit_status != 0:
-#         error_output = stderr.read().decode("utf-8")
-#         raise Exception(f"Error running QC script. Error: {error_output}")
+**Error**: {parsed_data.get('error', 'Unknown parsing error')}
 
-#     lines = stdout.readlines()
-#     for line in lines:
-#         print(line)
+*Unable to generate detailed summary. Please review the full log below.*
 
-#     print("Indicators QC job submitted")
+---
+"""
+    
+    # Build variables string
+    variables_str = ", ".join(parsed_data["variables"]) if parsed_data["variables"] else "Unknown"
+    
+    # Build year range string
+    year_start = parsed_data["years_processed"].get("start")
+    year_end = parsed_data["years_processed"].get("end")
+    if year_start and year_end:
+        if year_start == year_end:
+            years_str = str(year_start)
+        else:
+            years_str = f"{year_start} - {year_end}"
+    else:
+        years_str = "Unknown"
+    
+    # Status emoji mapping
+    status_emoji = {
+        "SUCCESS": "✅",
+        "PARTIAL SUCCESS": "⚠️",
+        "COMPLETED WITH RETRIES": "🔄",
+        "UNKNOWN": "❓",
+        "FAILED": "❌"
+    }
+    
+    status_icon = status_emoji.get(parsed_data["status"], "❓")
+    
+    # Build duration string
+    duration = parsed_data["timing"].get("duration", "Unknown")
+    
+    # Calculate success rate for display
+    completion_rate = parsed_data.get("completion_rate", 0)
+    
+    # Build summary
+    summary = f"""## 📊 ERA5 Processing Executive Summary
+
+### 🎯 Quick Overview
+| Metric | Value |
+|--------|-------|
+| **Status** | {status_icon} {parsed_data["status"]} |
+| **Variables** | {variables_str} |
+| **Years Processed** | {years_str} |
+| **Total Jobs** | {parsed_data["jobs"]["submitted"]} submitted |
+| **Duration** | {duration} |
+
+### 📈 Performance Metrics
+| Metric | Value |
+|--------|-------|
+| **Success Rate** | {completion_rate}% |
+| **Retries Required** | {parsed_data["retries"]["retries_attempted"]} jobs |
+| **Timeouts Detected** | {parsed_data["retries"]["timeouts_detected"]} jobs |
+"""
+    
+    # Add validation section if data available
+    if parsed_data["validation"]["expected_files"] > 0:
+        summary += f"""| **File Validation** | {parsed_data["validation"]["existing_files"]}/{parsed_data["validation"]["expected_files"]} files present |
+"""
+    
+    # Add timing details if available
+    if parsed_data["timing"]["start_time"]:
+        summary += f"""
+### ⏱️ Execution Timeline
+| Metric | Value |
+|--------|-------|
+| **Started** | {parsed_data["timing"]["start_time"]} |
+| **Completed** | {parsed_data["timing"]["end_time"]} |
+| **Total Duration** | {duration} |
+"""
+    
+    # Add issues section if any exist
+    if parsed_data["issues"]:
+        summary += f"""
+### ⚠️ Issues & Warnings
+"""
+        for issue in parsed_data["issues"]:
+            summary += f"- {issue}\n"
+    else:
+        summary += f"""
+### ✅ No Issues Detected
+All processing completed without warnings or errors.
+"""
+    
+    summary += "\n---\n"
+    
+    return summary
 
 
-# @task
-# def visual_qc_nb(ssh, working_dir, input_dir):
-#     """
-#     Task to run the visual quality control (QC) notebook to check the output of the indicator calculations.
+@task
+def create_full_log_artifact(ssh, repo_path: Path) -> str:
+    """Create complete log file artifact with intelligent summary"""
+    logger = get_run_logger()
+    
+    log_result = capture_remote_logs(ssh, repo_path)
+    
+    if log_result["status"] == "missing":
+        markdown_content = f"""# 📝 ERA5 Full Log
 
-#     Parameters:
-#     - ssh: Paramiko SSHClient object
-#     - working_dir: Directory where all of the processing takes place
-#     - input_dir: Directory containing source input data collection
-#     """
+**Status:** Log file not found  
+**Repository:** `{repo_path}`  
+**Timestamp:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
 
-#     repo_indicators_dir = f"{working_dir}/cmip6-utils/indicators"
-#     visual_qc_nb = f"{working_dir}/cmip6-utils/indicators/visual_qc.ipynb"
-#     run_visual_qc_script = f"{working_dir}/cmip6-utils/indicators/run_visual_qc.py"
-#     output_nb = f"{working_dir}/cmip6_indicators/qc/visual_qc_out.ipynb"
-#     slurm_dir = f"{working_dir}/cmip6_indicators/slurm"
+No log file was found at the expected location.
+"""
+    else:
+        log_content = log_result["content"]
+        
+        # Parse log content and generate summary
+        try:
+            parsed_data = parse_era5_log(log_content)
+            summary = generate_log_summary(parsed_data)
+            logger.info("Successfully generated log summary")
+        except Exception as e:
+            logger.warning(f"Failed to generate summary: {str(e)}")
+            summary = f"""## ⚠️ Summary Generation Error
 
-#     stdin, stdout, stderr = ssh.exec_command(
-#         f"python {run_visual_qc_script} \
-#             --input_dir '{input_dir}' \
-#             --slurm_dir '{slurm_dir}' \
-#             --working_dir '{working_dir}' \
-#             --visual_qc_nb '{visual_qc_nb}' \
-#             --output_nb '{output_nb}' \
-#             --repo_indicators_dir '{repo_indicators_dir}'"
-#     )
+Unable to generate automated summary: {str(e)}
 
-#     # Wait for the command to finish and get the exit status
-#     exit_status = stdout.channel.recv_exit_status()
+---
+"""
+        
+        # Truncate extremely large logs for the full content section
+        display_log_content = log_content
+        if len(log_content) > 100000:  # 100KB limit for full log
+            display_log_content = log_content[:100000] + "\n\n... (log truncated - showing first 100KB) ..."
+        
+        markdown_content = f"""# 📝 ERA5 Full Execution Log
 
-#     # Check the exit status for errors
-#     if exit_status != 0:
-#         error_output = stderr.read().decode("utf-8")
-#         raise Exception(f"Error running Visual QC script. Error: {error_output}")
+**Repository:** `{repo_path}`  
+**Timestamp:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}  
+**Size:** {len(log_result["content"])} characters
 
-#     lines = stdout.readlines()
-#     for line in lines:
-#         print(line)
+{summary}
 
-#     print(f"Visual QC notebook job submitted. See {output_nb} for results.")
+## 📋 Complete Log Output
+
+```bash
+{display_log_content}
+```
+
+---
+*Complete log captured by ERA5 Curation Flow*
+"""
+    
+    artifact_id = create_markdown_artifact(markdown_content)
+    logger.info(f"Created enhanced log artifact with summary: {artifact_id}")
+    return artifact_id
+
+
+
+
+
+

--- a/era5_4km/curation_functions.py
+++ b/era5_4km/curation_functions.py
@@ -305,9 +305,9 @@ def generate_log_summary(parsed_data: dict) -> str:
     completion_rate = parsed_data.get("completion_rate", 0)
 
     # Build summary
-    summary = f"""## 📊 ERA5 Processing Executive Summary
+    summary = f"""## ERA5 Curation Summary
 
-### 🎯 Quick Overview
+### Overview
 | Metric | Value |
 |--------|-------|
 | **Status** | {status_icon} {parsed_data["status"]} |
@@ -316,7 +316,7 @@ def generate_log_summary(parsed_data: dict) -> str:
 | **Total Jobs** | {parsed_data["jobs"]["submitted"]} submitted |
 | **Duration** | {duration} |
 
-### 📈 Performance Metrics
+### Performance
 | Metric | Value |
 |--------|-------|
 | **Success Rate** | {completion_rate}% |

--- a/era5_4km/curation_functions.py
+++ b/era5_4km/curation_functions.py
@@ -1,0 +1,241 @@
+from time import sleep
+from prefect import task
+import paramiko
+
+
+@task
+def check_for_nfs_mount(ssh, nfs_directory="/import/beegfs"):
+    """
+    Task to check if an NFS directory is mounted on the remote server via SSH.
+
+    Parameters:
+    - ssh: Paramiko SSHClient object
+    - nfs_directory: Path to the NFS directory to check for
+    """
+
+    stdin, stdout, stderr = ssh.exec_command(f"df -h | grep {nfs_directory}")
+
+    nfs_mounted = bool(stdout.read())
+
+    if not nfs_mounted:
+        raise Exception(f"NFS directory '{nfs_directory}' is not mounted")
+
+
+@task
+def clone_github_repository(ssh, branch, destination_directory):
+    """
+    Task to clone a GitHub repository via SSH and switch to a specific branch if it exists.
+
+    Parameters:
+    - ssh: Paramiko SSHClient object
+    - branch: Name of the branch to clone and switch to
+    - destination_directory: Directory to clone the repository into
+    """
+
+    target_directory = f"{destination_directory}/wrf-downscaled-era5-curation"
+    stdin, stdout, stderr = ssh.exec_command(
+        f"if [ -d '{target_directory}' ]; then echo 'true'; else echo 'false'; fi"
+    )
+
+    directory_exists = stdout.read().decode("utf-8").strip() == "true"
+
+    if directory_exists:
+        try:
+            # Directory exists, check the current branch
+            get_current_branch_command = (
+                f"cd {target_directory} && git pull && git branch --show-current"
+            )
+            stdin, stdout, stderr = ssh.exec_command(get_current_branch_command)
+            current_branch = stdout.read().decode("utf-8").strip()
+        except:
+            # If the current branch cannot be determined, assume it's the wrong branch
+            set_branch_to_main = f"cd {target_directory} && git checkout main"
+            stdin, stdout, stderr = ssh.exec_command(set_branch_to_main)
+
+            # Get the current branch again# Directory exists, check the current branch
+            get_current_branch_command = (
+                f"cd {target_directory} && git pull && git branch --show-current"
+            )
+            stdin, stdout, stderr = ssh.exec_command(get_current_branch_command)
+            current_branch = stdout.read().decode("utf-8").strip()
+
+        if current_branch != branch:
+            print(f"Change repository branch to branch {branch}...")
+            # If the current branch is different from the desired branch, switch to the correct branch
+            switch_branch_command = f"cd {target_directory} && git checkout {branch}"
+            stdin, stdout, stderr = ssh.exec_command(switch_branch_command)
+
+        print(f"Pulling the GitHub repository on branch {branch}...")
+
+        # Run the Git pull command to pull the repository
+        git_pull_command = f"cd {target_directory} && git pull origin {branch}"
+        stdin, stdout, stderr = ssh.exec_command(git_pull_command)
+
+        # Wait for the Git command to finish and get the exit status
+        exit_status = stdout.channel.recv_exit_status()
+
+        # Check the exit status for errors
+        if exit_status != 0:
+            raise Exception(
+                f"Error cloning the GitHub repository. Exit status: {exit_status}"
+            )
+    else:
+        print(f"Cloning the GitHub repository on branch {branch}...")
+        # Run the Git clone command to clone the repository
+        git_command = f"cd {destination_directory} && git clone -b {branch} https://github.com/ua-snap/wrf-downscaled-era5-curation.git"
+        stdin, stdout, stderr = ssh.exec_command(git_command)
+
+        # Wait for the Git command to finish and get the exit status
+        exit_status = stdout.channel.recv_exit_status()
+
+        # Check the exit status for errors
+        if exit_status != 0:
+            error_output = stderr.read().decode("utf-8")
+            raise Exception(
+                f"Error cloning the GitHub repository. Error: {error_output}"
+            )
+
+
+@task
+def install_conda_environment(ssh, conda_env_name, conda_env_file):
+    """
+    Task to check for a Python Conda environment and install it from an environment file
+    if it doesn't exist on the user's account via SSH. It also checks for Miniconda installation
+    and installs Miniconda if it doesn't exist.
+
+    Parameters:
+    - ssh: Paramiko SSHClient object
+    - conda_env_name: Name of the Conda environment to create/install
+    - conda_env_file: Path to the Conda environment file (.yml) to use for installation
+    """
+
+    # Check if the Miniconda directory exists in the user's home directory
+    stdin, stdout, stderr = ssh.exec_command(
+        "test -d $HOME/miniconda3 && echo 1 || echo 0"
+    )
+
+    miniconda_found = int(stdout.read())
+    miniconda_installed = bool(miniconda_found)
+
+    if not miniconda_installed:
+        print("Miniconda directory not found. Installing Miniconda...")
+        # Download and install Miniconda
+        install_miniconda_cmd = "wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && bash miniconda.sh -b -p $HOME/miniconda3"
+        stdin, stdout, stderr = ssh.exec_command(install_miniconda_cmd)
+
+        # Wait for the command to finish and get the exit status
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status != 0:
+            error_output = stderr.read().decode("utf-8")
+            raise Exception(f"Error installing Miniconda. Error: {error_output}")
+
+        print("Miniconda installed successfully")
+
+    # Check if the Conda environment already exists
+    stdin, stdout, stderr = ssh.exec_command(
+        f"source $HOME/miniconda3/bin/activate && $HOME/miniconda3/bin/conda env list | grep {conda_env_name}"
+    )
+
+    conda_env_exists = bool(stdout.read())
+
+    if not conda_env_exists:
+        print(f"Conda environment '{conda_env_name}' does not exist. Installing...")
+
+        # Install the Conda environment from the environment file
+        install_cmd = f"source $HOME/miniconda3/bin/activate && $HOME/miniconda3/bin/conda env create -n {conda_env_name} -f {conda_env_file}"
+        stdin, stdout, stderr = ssh.exec_command(install_cmd)
+
+        # Wait for the command to finish and get the exit status
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status == 0:
+            print(f"Conda environment '{conda_env_name}' installed successfully")
+        else:
+            error_output = stderr.read().decode("utf-8")
+            raise Exception(
+                f"Error installing Conda environment '{conda_env_name}'. Error: {error_output}"
+            )
+    else:
+        print(f"Conda environment '{conda_env_name}' already exists.")
+
+
+# @task
+# def qc(ssh, working_dir, input_dir):
+#     """
+#     Task to run the quality control (QC) script to check the output of the indicator calculations.
+
+#     Parameters:
+#     - ssh: Paramiko SSHClient object
+#     - working_dir: Directory to where all of the processing takes place
+#     """
+
+#     run_qc_script = f"{working_dir}/cmip6-utils/indicators/run_qc.py"
+#     qc_script = f"{working_dir}/cmip6-utils/indicators/qc.py"
+#     output_dir = f"{working_dir}/cmip6_indicators"
+#     slurm_dir = f"{working_dir}/cmip6_indicators/slurm"
+
+#     stdin, stdout, stderr = ssh.exec_command(
+#         f"conda activate cmip6-utils\n"
+#         f"python {run_qc_script} \
+#             --qc_script '{qc_script}' \
+#             --in_dir '{input_dir}' \
+#             --out_dir '{output_dir}' \
+#             --slurm_dir '{slurm_dir}'"
+#     )
+
+#     # Wait for the command to finish and get the exit status
+#     exit_status = stdout.channel.recv_exit_status()
+
+#     # Check the exit status for errors
+#     if exit_status != 0:
+#         error_output = stderr.read().decode("utf-8")
+#         raise Exception(f"Error running QC script. Error: {error_output}")
+
+#     lines = stdout.readlines()
+#     for line in lines:
+#         print(line)
+
+#     print("Indicators QC job submitted")
+
+
+# @task
+# def visual_qc_nb(ssh, working_dir, input_dir):
+#     """
+#     Task to run the visual quality control (QC) notebook to check the output of the indicator calculations.
+
+#     Parameters:
+#     - ssh: Paramiko SSHClient object
+#     - working_dir: Directory where all of the processing takes place
+#     - input_dir: Directory containing source input data collection
+#     """
+
+#     repo_indicators_dir = f"{working_dir}/cmip6-utils/indicators"
+#     visual_qc_nb = f"{working_dir}/cmip6-utils/indicators/visual_qc.ipynb"
+#     run_visual_qc_script = f"{working_dir}/cmip6-utils/indicators/run_visual_qc.py"
+#     output_nb = f"{working_dir}/cmip6_indicators/qc/visual_qc_out.ipynb"
+#     slurm_dir = f"{working_dir}/cmip6_indicators/slurm"
+
+#     stdin, stdout, stderr = ssh.exec_command(
+#         f"python {run_visual_qc_script} \
+#             --input_dir '{input_dir}' \
+#             --slurm_dir '{slurm_dir}' \
+#             --working_dir '{working_dir}' \
+#             --visual_qc_nb '{visual_qc_nb}' \
+#             --output_nb '{output_nb}' \
+#             --repo_indicators_dir '{repo_indicators_dir}'"
+#     )
+
+#     # Wait for the command to finish and get the exit status
+#     exit_status = stdout.channel.recv_exit_status()
+
+#     # Check the exit status for errors
+#     if exit_status != 0:
+#         error_output = stderr.read().decode("utf-8")
+#         raise Exception(f"Error running Visual QC script. Error: {error_output}")
+
+#     lines = stdout.readlines()
+#     for line in lines:
+#         print(line)
+
+#     print(f"Visual QC notebook job submitted. See {output_nb} for results.")

--- a/era5_4km/curation_functions.py
+++ b/era5_4km/curation_functions.py
@@ -4,11 +4,49 @@ import tarfile
 import subprocess
 from pathlib import Path
 from datetime import datetime
+import time
 
 import paramiko
 from prefect import task, get_run_logger
 from prefect.artifacts import create_markdown_artifact
 
+# ---------------------------------------------------------------------------
+# General SSH utility
+# ---------------------------------------------------------------------------
+
+def execute_ssh_with_logging(
+    ssh: paramiko.SSHClient,
+    command: str,
+    description: str,
+    remote_name: str = "remote",
+):
+    """Execute a single SSH command with detailed Prefect-style logging.
+
+    Returns tuple(stdout, stderr). Raises Exception on non-zero exit.
+    """
+    logger = get_run_logger()
+    logger.info(f"[{remote_name}] {description}")
+    logger.debug(f"{remote_name} CMD: {command}")
+
+    stdin, stdout, stderr = ssh.exec_command(command)
+    exit_status = stdout.channel.recv_exit_status()
+    out = stdout.read().decode().strip()
+    err = stderr.read().decode().strip()
+
+    if exit_status != 0:
+        msg = (
+            f"SSH command failed – {description} (exit {exit_status})\nCMD: {command}"
+        )
+        if err:
+            msg += f"\nSTDERR: {err}"
+        if out:
+            msg += f"\nSTDOUT: {out}"
+        raise Exception(msg)
+
+    if out:
+        logger.debug(out)
+
+    return out, err
 
 @task
 def check_for_nfs_mount(ssh, nfs_directory="/import/beegfs"):
@@ -165,30 +203,6 @@ def install_conda_environment(ssh, conda_env_name, conda_env_file):
             )
     else:
         print(f"Conda environment '{conda_env_name}' already exists.")
-
-
-@task
-def tar_directory(directory, output_file):
-    with tarfile.open(output_file, "w:gz") as tar:
-        print("Creating new tar file of ERA5 data...")
-        for item in os.listdir(directory):
-            item_path = os.path.join(directory, item)
-            tar.add(item_path, arcname=item)
-    return output_file
-
-
-@task
-def copy_tarfile_to_storage_server(tar_file, target_directory):
-    print("Copying tar file to NFS server via scp...")
-    try:
-        subprocess.run(
-            ["scp", tar_file, f"poseidon.snap.uaf.edu:{target_directory}"], check=True
-        )
-        print(
-            f"File {tar_file} successfully copied to poseidon.snap.uaf.edu:{target_directory}"
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Error copying file: {e}")
 
 
 @task
@@ -571,3 +585,26 @@ Unable to generate automated summary: {str(e)}
     artifact_id = create_markdown_artifact(markdown_content)
     logger.info(f"Created enhanced log artifact with summary: {artifact_id}")
     return artifact_id
+
+
+
+@task
+def log_system_state(ssh, era5_output_dir: str, variables_list: list):
+    """Log current system state for debugging"""
+    logger = get_run_logger()
+    
+    try:
+        # Check overall disk usage
+        stdout, _ = execute_ssh_with_logging(ssh, f"df -h {era5_output_dir}", "Check disk usage")
+        logger.info(f"Disk usage: {stdout}")
+        
+        # Check file counts per variable
+        for var in variables_list:
+            var_dir = f"{era5_output_dir}/{var}"
+            stdout, _ = execute_ssh_with_logging(
+                ssh, f"find '{var_dir}' -name '*.nc' | wc -l", f"Count files in {var}"
+            )
+            logger.info(f"File count for {var}: {stdout.strip()} files")
+            
+    except Exception as e:
+        logger.warning(f"Could not gather diagnostic info: {e}")


### PR DESCRIPTION
This PR introduces two new flows for processing (on Chinook) and archiving (on Poseidon) WRF-downscaled ERA5 4km climate data.

### Two New Flows in `era5_4km/`:
- **`curate_era5_4km.py`**: Main processing flow that orchestrates ERA5 data processing on Chinook by cloning that repo and setting off the jobs
- **`archive_era5.py`**: Archival flow that compresses and transfers processed data to Poseidon storage

### Testing Instructions
#### Deploy the flows
 - Read the full `README` and follow instructions to deploy the flows such that they are polling and ready for runs.
 - I think I have everything documented here, so if you can't even deploy these flows please ping me!
 - Verify the flows appear in Prefect UI without errors

#### Run the `curate_era5_4km` flow
Change these parameters for a minimal test:
```json
{
  "ssh_username": "your_username",
  "variables": "t2_min",
  "start_year": 2000,
  "end_year": 2006,
  "max_concurrent": 5
}
```

- Verify you can see the log artifact in the Prefect UI
- Verify the artifact matches what you expect in terms of the flow params provided
- After flow completion, SSH to Chinook and verify that the file system state matches what Prefect tells us (this is all assuming that you didn't fiddle with the output location very much):
```bash
ssh $USER@chinook04.rcs.alaska.edu

# Verify variable directory and output *.nc files were created
# Verify file sizes are reasonable too (not empty)
ls -lhrt /beegfs/CMIP6/$USER/curated_wrf_era5-04km/t2_min/

# Check some log files
ls -la /beegfs/CMIP6/$USER/wrf-downscaled-era5-curation/logs/
cat /beegfs/CMIP6/$USER/wrf-downscaled-era5-curation/logs/submit_era5_jobs/submit_era5_jobs.log
```

#### Run the `archive_era5` flow
Try these parameters for a simple test
```json
{
  "ssh_username": "your_username",
  "variables": "all",
  "cleanup_source_archives": false
}
```
Notes on above ☝️ 
 - I've been running this as `snapdata` but you can try as your own user - it'll just need to match the parent user directory of the output on Chinook BeeGFS
 - `all` only includes `t2_min` in this particular example, but `all` should grab everything produced under your user
 - default cleanup option is true (removes the tar files from Chinook afterward), but this is probably a good option for testing

- Verify behavior with some manual inspection on Poseidon
```bash

# Check the archived tar file
ls -lh /workspace/Shared/Tech_Projects/daily_wrf_downscaled_era5_4km/t2_min/t2_min_era5_4km_archive.tar.gz
```

- Verify behavior with some manual inspection on Chinook
```bash
# Check if temporary tar files were cleaned up (should not exist if cleanup_source_archives=true)
ls -la /beegfs/CMIP6/snapdata/curated_wrf_era5-04km/t2_min_era5_4km_archive.tar.gz

# Original data should still exist
ls -la /beegfs/CMIP6/snapdata/curated_wrf_era5-04km/t2_min/
```
- Verify you can see the artifact, and the contents match your expectations

## Checklist

- [ ] Both flows deploy successfully
- [ ] Processing flow executes end-to-end
- [ ] Output files appear in correct Chinook directories
- [ ] Archival flow creates and transfers tar files
- [ ] Archive files are accessible on Poseidon
- [ ] Artifacts work correctly

## Notes

- For a "full" run of the curation pipeline, stick with the default years but try this list of "Tier 1" variables: `rainnc_sum,rh2_max,rh2_mean,rh2_min,t2_max,t2_mean,t2_min,wdir10_mean,wspd10_max,wspd10_mean,seaice_max`
- Oh and crank that `--max_concurrent` to 💯 (seriously, set it to `100` these jobs are capped at 10 minutes each (per variable per year)
