### PR TITLE
Minor changes for Prefect 2.x compatibility, and a couple other small improvements

### DIFF
--- a/era5_4km/archive_era5.py
+++ b/era5_4km/archive_era5.py
@@ -484,6 +484,7 @@ def archive_era5(
             logger.error(
                 f"❌ Archival failed completely! All {failed_count} variables failed."
             )
+            raise
         else:
             logger.warning(
                 f"⚠️ Partial success: {success_count} succeeded, {failed_count} failed."

--- a/era5_4km/archive_era5.py
+++ b/era5_4km/archive_era5.py
@@ -515,7 +515,7 @@ if __name__ == "__main__":
             "destination_directory": Path(
                 "/workspace/Shared/Tech_Projects/daily_wrf_downscaled_era5_4km"
             ),
-            "variables": "t2_mean,t2_min,t2_max",  # or "all"
+            "variables": "all",
             "cleanup_source_archives": True,
         },
     )

--- a/era5_4km/curate_era5_4km.py
+++ b/era5_4km/curate_era5_4km.py
@@ -80,7 +80,6 @@ def submit_era5_jobs(
 
         repo_path = working_directory / "wrf-downscaled-era5-curation"
 
-        @task
         def build_and_run_job_submission_script(
             ssh,
             repo_path,
@@ -177,6 +176,7 @@ def submit_era5_jobs(
 
 if __name__ == "__main__":
     submit_era5_jobs.serve(
+        name="era5-4k-curation",
         parameters={
             "ssh_username": "snapdata",
             "ssh_private_key_path": "/Users/cparr/.ssh/id_rsa",
@@ -190,5 +190,5 @@ if __name__ == "__main__":
             "max_concurrent": 60,
             "overwrite": False,
             "no_retry": False,
-        }
+        },
     )

--- a/era5_4km/curation_functions.py
+++ b/era5_4km/curation_functions.py
@@ -7,7 +7,6 @@ from prefect import task, get_run_logger
 from prefect.artifacts import create_markdown_artifact
 
 
-@task
 def execute_ssh_with_logging(
     ssh: paramiko.SSHClient,
     command: str,
@@ -67,7 +66,6 @@ def execute_ssh_with_logging(
     return out, err
 
 
-@task
 def capture_remote_logs(ssh, repo_path: Path, log_file_path: str = None) -> dict:
     """
     Capture logs from remote HPC and create Prefect artifacts
@@ -137,7 +135,7 @@ def parse_era5_log(log_content: str) -> dict:
                 "existing_files": 0,
                 "missing_files": 0,
             },
-            "issues": []
+            "issues": [],
         }
 
         lines = log_content.split("\n")
@@ -384,7 +382,6 @@ All processing completed without warnings or errors.
     return summary
 
 
-@task
 def create_full_log_artifact(ssh, repo_path: Path) -> str:
     """Create complete log file artifact with summary"""
     logger = get_run_logger()


### PR DESCRIPTION
This PR makes a few minor changes to PR #84 for Prefect 2.x compatibility. I was able to run through all of the tests described in PR #84 successfully with these changes.

Specifically, Prefect 2.x complains when you try to run a `@task` within a `@task`. I ran into this issue when reviewing Kyle's recent Prefect PR also. You can get around this simply by removing the `@task` decorator from the nested function call and everything still works as intended (but with less granularity in the Prefect flow graph, I think).

Prefect 2.x also insisted that `curate_era5_4km.py` needed to have a name specified, so I've added one.

I've also changed this line from:

```
"variables": "t2_mean,t2_min,t2_max"
```

To:

```
"variables": "all"
```

Here:

https://github.com/ua-snap/prefect/blob/7296f9cb51ec5f59f07094decd6463009560f757/era5_4km/archive_era5.py#L519

Before this change, Prefect wasn't letting me specify "all" in the `variables` field through the web interface. When I entered "all", it reverted back to "t2_mean,t2_min,t2_max" behind the scenes. I'm not sure why, but possibly due to a mismatch of the default variables specified in the line above vs. here (or something):

https://github.com/ua-snap/prefect/blob/4e959e1126bc12ed76867a92123f2c1dda238d65/era5_4km/archive_era5.py#L385

I've also added a `raise` statement for a complete archival fail. I ran into a complete archival fail while testing before I had my SSH keys set up properly between Chinook and Poseidon and noticed that Prefect reported the flow as "Completed". I figured it should say "Failed" to make it super clear at the top of the page that the archival process failed entirely.

If these changes look good to you, @charparr, merge this into `downscaled_era5`, and then I'll merge `downscaled_era5` into `main`. Thanks!!