### PR TITLE
Add Tasks to Ingest the "WCS Only" Daily SLIE Coverages

### DIFF
--- a/rasdaman/ardac_beaufort_daily_slie.py
+++ b/rasdaman/ardac_beaufort_daily_slie.py
@@ -15,7 +15,9 @@ def ardac_beaufort_daily_slie(
 
     ingest_tasks.untar_file(source_file, ingest_directory)
 
-    ingest_tasks.run_ingest(ingest_directory, conda_env="hydrology")
+    # why two ingests? one for WMS, and one for WCS only
+    ingest_tasks.run_ingest(ingest_directory, ingest_file="ingest.json", conda_env="hydrology")
+    ingest_tasks.run_ingest(ingest_directory, ingest_file="ingest_wcs_only.json", conda_env="hydrology")
 
 
 if __name__ == "__main__":

--- a/rasdaman/ardac_beaufort_daily_slie.py
+++ b/rasdaman/ardac_beaufort_daily_slie.py
@@ -22,7 +22,7 @@ def ardac_beaufort_daily_slie(
 
 if __name__ == "__main__":
     ardac_beaufort_daily_slie.serve(
-        name="Rasdaman Coverage: ardac_beaufort_daily_slie",
+        name="Rasdaman Coverages: ardac_beaufort_daily_slie, ardac_beaufort_daily_slie_wcs",
         tags=["ARDAC", "Landfast Sea Ice"],
         parameters={
             "branch_name": "main",

--- a/rasdaman/ardac_chukchi_daily_slie.py
+++ b/rasdaman/ardac_chukchi_daily_slie.py
@@ -15,7 +15,9 @@ def ardac_chukchi_daily_slie(
 
     ingest_tasks.untar_file(source_file, ingest_directory)
 
-    ingest_tasks.run_ingest(ingest_directory, conda_env="hydrology")
+    # why two ingests? one for WMS, and one for WCS only
+    ingest_tasks.run_ingest(ingest_directory, ingest_file="ingest.json", conda_env="hydrology")
+    ingest_tasks.run_ingest(ingest_directory, ingest_file="ingest_wcs_only.json", conda_env="hydrology")
 
 
 if __name__ == "__main__":

--- a/rasdaman/ardac_chukchi_daily_slie.py
+++ b/rasdaman/ardac_chukchi_daily_slie.py
@@ -22,7 +22,7 @@ def ardac_chukchi_daily_slie(
 
 if __name__ == "__main__":
     ardac_chukchi_daily_slie.serve(
-        name="Rasdaman Coverage: ardac_chukchi_daily_slie",
+        name="Rasdaman Coverages: ardac_chukchi_daily_slie, ardac_chukchi_daily_slie_wcs",
         tags=["ARDAC", "Landfast Sea Ice"],
         parameters={
             "branch_name": "main",


### PR DESCRIPTION
XREF https://github.com/ua-snap/rasdaman-ingest/pull/134

This PR encapsulates the xref'd PR in Prefect.

I tested these flows by commenting out the task for the existing coverage - changing the flow to look like this:
```python
# ingest_tasks.run_ingest(ingest_directory, ingest_file="ingest.json", conda_env="hydrology")
ingest_tasks.run_ingest(ingest_directory, ingest_file="ingest_wcs_only.json", conda_env="hydrology")
```

However, ultimately you could run both tasks, because we need to update the production version of that coverage anyway to reflect the most recent data delivery from Andy.

I tested with these flow parameters:

```json
{
  "branch_name": "daily_slie_tile_vroom",
  "working_directory": "/opt/rasdaman/user_data/snapdata/cp_dev_ras_ingest",
  "ingest_directory": "/opt/rasdaman/user_data/snapdata/cp_dev_ras_ingest/rasdaman-ingest/ardac/landfast_sea_ice_chukchi_daily",
  "source_file": "/workspace/Shared/Tech_Projects/landfast_sea_ice/Chukchi_NetCDFs.tar.gz"
}
```

Although I think you could use the default `working_directory` and `ingest_directory` here.