### PR TITLE
add task to ingest ERA5 WCS optimized flavors

### DIFF
--- a/rasdaman/wrf_downscaled_era5_4km.py
+++ b/rasdaman/wrf_downscaled_era5_4km.py
@@ -54,13 +54,13 @@ def ingest_wrf_downscaled_era5_4km(
     # for each variable, we must
     # copy the data from the backed up source, and untar it and flatten it
     # then we need to combine the data into a single file
-    # run the ingest command, these are all in the ingest directory with names like this:
-    # t2_min_ingest.json  rh2_mean_ingest.json  seaice_max_ingest.json
-
+    # run two ingest commands, one for the "normal" coverage and one for the WCS optimized coverage 
+    # name scheme: t2_min_ingest.json, t2_min__ingest_wcs_only.json
     for variable in era5_variables:
         dest_var_dir = f"{destination_directory}/{variable}"
         source_var_dir = f"{source_directory}/{variable}"
         var_ingest_recipe = f"{variable}_ingest.json"
+        var_ingest_recipe_wcs_only = f"{variable}_ingest_wcs_only.json"
 
         ingest_tasks.copy_data_from_nfs_mount(source_var_dir, destination_directory)
         ingest_tasks.untar_file(
@@ -73,6 +73,8 @@ def ingest_wrf_downscaled_era5_4km(
         run_combine_netcdfs_script(ingest_directory, variable)
 
         ingest_tasks.run_ingest(ingest_directory, var_ingest_recipe)
+
+        ingest_tasks.run_ingest(ingest_directory, var_ingest_recipe_wcs_only)
 
         # for each ingest build a WMS link artifact
         wms_url = (
@@ -113,7 +115,7 @@ if __name__ == "__main__":
     ]
 
     ingest_wrf_downscaled_era5_4km.serve(
-        name="Rasdaman Coverage: ERA5 4km Daily Summaries (era5_4km_daily_$variable)",
+        name="Rasdaman Coverage: ERA5 4km Daily Summaries Inlcuding WCS Optimized Versions(era5_4km_daily_$variable, era5_4km_daily_$variable_wcs)",
         tags=["ARDAC", "ERA5"],
         parameters={
             "branch_name": "main",


### PR DESCRIPTION
#XREF https://github.com/ua-snap/rasdaman-ingest/pull/135

This PR encapsulates the xref'd PR in Prefect.

The flow for each variable now has two ingest tasks - one for the "standard" version that permits WMS, and one for the WCS-optimized version. You'll need to change the `rasdaman-ingest` branch name to "era5_tile_vroom" assuming that this has not already been merged into main. The tasks to copy the data from storage and perform the netcdf combination wizardry can take a while, so you might let this run overnight.

Feel free to delete the existing `era5_*` coverages on Zeus, they aren't in production and, as we'll test here, we can regenerate them pretty easily.

You'll need to test this flow as the 'snapdata' user on Zeus. You can listen on the port if you want the Dask dashboard, but that is optional (only reason you'd do this is to watch the colorful bars fly around while the netCDF files merge together)
```sh
 ssh -L 8787:127.0.0.1:8787 snapdata@datacubes.earthmaps.io
```

Clone the `prefect` repo to a directory on Zeus somewhere under the `snapdata` home.
I used `/home/snapdata/cp_prefect_dev/`

From the prefect directory, launch the flow to run these ingest recipes.

```sh
python wrf_downscaled_era5_4km.py`
```

Other than the branch name, you should be able to proceed with the default parameters. Let me know if you get stuck though!