### PR TITLE
Use patch interpolation for regridding in CMIP6 downscale pipeline

### DIFF
--- a/downscaling/downscale_cmip6.py
+++ b/downscaling/downscale_cmip6.py
@@ -572,7 +572,7 @@ def downscale_cmip6(
     intermediate_out_dir_name = "intermediate_regrid"
     regrid_cmip6_intermediate_kwargs = base_kwargs.copy()
     regrid_variables = get_regrid_variables(variables)
-    interp_method = "bilinear"
+    interp_method = "patch"
     regrid_cmip6_intermediate_kwargs.update(
         {
             "cmip6_dir": cmip6_dir,


### PR DESCRIPTION
This PR switches from using `blinear` interpolation to `patch` interpolation to remove the grid-like artifacts in the downscaled GFDL-ESM4 DTR outputs (and possibly the outputs for other models too, but less noticeable if so).

I'm going to go ahead and self-merge this PR because it's a single-line change that we have already reviewed together in our weekly CMIP6 meeting.