### PR TITLE
Updates Prefect script to use new location for sea ice concentration data

### DIFF
--- a/hsia/generate_annual_hsia_rasdaman_data.py
+++ b/hsia/generate_annual_hsia_rasdaman_data.py
@@ -63,11 +63,11 @@ if __name__ == "__main__":
         name="Update Annual Sea Ice GeoTIFFs for ingest into Rasdaman",
         tags=["HSIA", "Sea Ice", "Create New Data"],
         parameters={
-            "years": 2024,
+            "years": 2025,
             "home_directory": "/home/snapdata/",
             "working_directory": "/opt/rasdaman/user_data/snapdata/hsia_updates/",
             "source_tar_file": "/workspace/Shared/Tech_Projects/Sea_Ice_Atlas/final_products/rasdaman_hsia_arctic_production_tifs.tgz",
             "tif_directory": "/opt/rasdaman/user_data/snapdata/hsia_updates/rasdaman_hsia_arctic_production_tifs",
-            "conda_env": "hydrology",
+            "conda_env": "hsia_updates",
         },
     )

--- a/hsia/hsia_tasks.py
+++ b/hsia/hsia_tasks.py
@@ -150,8 +150,11 @@ def download_new_nsidc_data(year):
         commanda = 'wget --load-cookies ~/.urs_cookies --save-cookies ~/.urs_cookies --keep-session-cookies --no-check-certificate --auth-no-challenge=on -r --reject "index.html*" -np -nd -e robots=off --user {} --password "{}" -P {} '.format(
             username, password, out_dir
         )
-        commandb = "https://n5eil01u.ecs.nsidc.org/PM/NSIDC-0051.002/{}.{}.01/NSIDC0051_SEAICE_PS_N25km_{}{}_v2.0.nc".format(
-            str(year), month, str(year), month
+        print(year)
+        flag = "F17" if int(year) <= 2024 else "am2"
+
+        commandb = "https://noaadata.apps.nsidc.org/NOAA/G02202_V6/north/monthly/sic_psn25_{}{}_{}_v06r00.nc".format(
+            str(year), month, flag
         )
         os.system(commanda + commandb)
 
@@ -160,8 +163,9 @@ def download_new_nsidc_data(year):
 def generate_annual_sea_ice_geotiffs(year, output_directory, conda_env="hydrology"):
     # Generate annual Sea Ice GeoTIFFs
     for month in range(1, 13):
+        flag = "F17" if int(year) <= 2024 else "am2"
         input_netcdf = (
-            f"/tmp/nsidc_raw/{year}/NSIDC0051_SEAICE_PS_N25km_{year}{month:02d}_v2.0.nc"
+            f"/tmp/nsidc_raw/{year}/sic_psn25_{year}{month:02d}_{flag}_v06r00.nc"
         )
         output_tiff = f"{output_directory}/seaice_conc_sic_mean_pct_monthly_panarctic_{year}_{month:02d}.tif"
         try:

--- a/hsia/hsia_tasks.py
+++ b/hsia/hsia_tasks.py
@@ -150,7 +150,6 @@ def download_new_nsidc_data(year):
         commanda = 'wget --load-cookies ~/.urs_cookies --save-cookies ~/.urs_cookies --keep-session-cookies --no-check-certificate --auth-no-challenge=on -r --reject "index.html*" -np -nd -e robots=off --user {} --password "{}" -P {} '.format(
             username, password, out_dir
         )
-        print(year)
         flag = "F17" if int(year) <= 2024 else "am2"
 
         commandb = "https://noaadata.apps.nsidc.org/NOAA/G02202_V6/north/monthly/sic_psn25_{}{}_{}_v06r00.nc".format(

--- a/hsia/seaice/seaice.py
+++ b/hsia/seaice/seaice.py
@@ -12,31 +12,31 @@ def netcdf_to_geotiff(input_netcdf, output_tiff, conda_env="hydrology"):
     variable = dataset["cdr_seaice_conc_monthly"].isel(time=0).values
     qa_flag = dataset["cdr_seaice_conc_monthly_qa_flag"].isel(time=0).values
 
-    # Initialize output array - start with scaled concentration (0-100)
     rescaled_data = np.zeros_like(variable, dtype=np.float32)
 
-    # Copy valid ice concentration values and scale to 0-100
     valid_mask = ~np.isnan(variable)
+
+    # Rescale data to 0-100 range for valid ocean pixels
     rescaled_data[valid_mask] = variable[valid_mask] * 100
 
-    # Apply landmask based on NaN values and QA flags
     # NaN with QA=0 are land pixels (not in ocean)
-    # QA=16/80 pixels (bit 4) have conc=0 and should remain as ocean, not land
     nan_land_mask = np.isnan(variable) & (qa_flag == 0)
-    rescaled_data[nan_land_mask] = 254  # Land
 
-    # Mark remaining NaN values (non-land, outside data area) as nodata
-    # This prevents gdalwarp from expanding land into these areas
+    # 254 represents land in the output GeoTIFF
+    rescaled_data[nan_land_mask] = 254
+
+    # Mark remaining NaN values as having no data
     remaining_nan = np.isnan(variable) & (qa_flag != 0)
-    rescaled_data[remaining_nan] = 255  # NoData
 
-    # Convert to uint8 for output
+    # 255 represents no data in the GeoTIFF
+    rescaled_data[remaining_nan] = 255
+
     rescaled_data = rescaled_data.astype(np.uint8)
 
-    # Pixel size is 25000 to match the 25 km grid
+    # 25km grid
     pixel_size = 25000.0
     geotransform = (-3850000.0, pixel_size, 0.0, 5850000.0, 0.0, -pixel_size)
-    # Define CRS using proj4 string to avoid PROJ database version issues
+
     source_crs = rasterio.CRS.from_proj4(
         "+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +x_0=0 +y_0=0 +a=6378273 +b=6356889.449 +units=m +no_defs"
     )
@@ -57,8 +57,6 @@ def netcdf_to_geotiff(input_netcdf, output_tiff, conda_env="hydrology"):
             ),
         ) as src:
             src.write(rescaled_data, 1)
-
-            # This reprojects the GeoTIFF data in memory to EPSG:3572
             transform, width, height = calculate_default_transform(
                 src.crs, target_crs, src.width, src.height, *src.bounds
             )

--- a/hsia/seaice/seaice.py
+++ b/hsia/seaice/seaice.py
@@ -9,25 +9,40 @@ import os
 def netcdf_to_geotiff(input_netcdf, output_tiff, conda_env="hydrology"):
     dataset = xr.open_dataset(input_netcdf)
 
-    variable = dataset["F17_ICECON"].isel(time=0).values
+    variable = dataset["cdr_seaice_conc_monthly"].isel(time=0).values
+    qa_flag = dataset["cdr_seaice_conc_monthly_qa_flag"].isel(time=0).values
 
-    # Need to scale the data to match the concentration values for the TIFFs
-    rescaled_data = variable * 100
+    # Initialize output array - start with scaled concentration (0-100)
+    rescaled_data = np.zeros_like(variable, dtype=np.float32)
 
-    rescaled_data[np.isclose(rescaled_data, 100.4)] = 251  # Circular mask
-    rescaled_data[np.isclose(rescaled_data, 100.8)] = 252  # Unused
-    rescaled_data[np.isclose(rescaled_data, 101.2)] = 253  # Coastlines
-    rescaled_data[np.isclose(rescaled_data, 101.6)] = 254  # Land mask
-    rescaled_data[np.isclose(rescaled_data, 102.0)] = 255  # Missing data
+    # Copy valid ice concentration values and scale to 0-100
+    valid_mask = ~np.isnan(variable)
+    rescaled_data[valid_mask] = variable[valid_mask] * 100
 
-    # Matches the original TIFFs for output consistency
+    # Apply landmask based on NaN values and QA flags
+    # NaN with QA=0 are land pixels (not in ocean)
+    # QA=16/80 pixels (bit 4) have conc=0 and should remain as ocean, not land
+    nan_land_mask = np.isnan(variable) & (qa_flag == 0)
+    rescaled_data[nan_land_mask] = 254  # Land
+
+    # Mark remaining NaN values (non-land, outside data area) as nodata
+    # This prevents gdalwarp from expanding land into these areas
+    remaining_nan = np.isnan(variable) & (qa_flag != 0)
+    rescaled_data[remaining_nan] = 255  # NoData
+
+    # Convert to uint8 for output
     rescaled_data = rescaled_data.astype(np.uint8)
 
     # Pixel size is 25000 to match the 25 km grid
     pixel_size = 25000.0
     geotransform = (-3850000.0, pixel_size, 0.0, 5850000.0, 0.0, -pixel_size)
-    source_crs = rasterio.CRS.from_string("EPSG:3411")
-    target_crs = "EPSG:3572"
+    # Define CRS using proj4 string to avoid PROJ database version issues
+    source_crs = rasterio.CRS.from_proj4(
+        "+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +x_0=0 +y_0=0 +a=6378273 +b=6356889.449 +units=m +no_defs"
+    )
+    target_crs = rasterio.CRS.from_proj4(
+        "+proj=laea +lat_0=90 +lon_0=180 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs"
+    )
 
     with rasterio.MemoryFile() as memfile:
         with memfile.open(
@@ -72,9 +87,13 @@ def netcdf_to_geotiff(input_netcdf, output_tiff, conda_env="hydrology"):
     # Use gdalwarp to overwrite the file with the correct coordinates
     # We found that using rasterio for the warp resulted in incorrect coordinates
     # which caused the data to not properly ingest into the coverage.
+    # Use nearest neighbor resampling to preserve categorical values (land=254, etc.)
+    # Initialize destination to 0 (ocean) and use nodata=255 to prevent edge expansion
     os.system(
-        f". /opt/miniconda3/bin/activate && conda activate {conda_env} && "
-        "gdalwarp -overwrite -q -multi -t_srs EPSG:3572 -te_srs EPSG:3572 "
+        f"gdalwarp -overwrite -q -multi -r near -ot Byte "
+        "-srcnodata 255 -dstnodata 255 "
+        "-wo INIT_DEST=0 "
+        "-t_srs EPSG:3572 -te_srs EPSG:3572 "
         "-te -4862550.515 -4894840.007 4870398.248 4889334.803 "
         "-tr 17075.348707767432643 -17075.348707767432643 "
         f"'temp.tif' '{output_tiff}'"


### PR DESCRIPTION
**Summary**

This PR updates the script used by the Prefect flow for generating the sea ice concentration used in the hsia_arctic_production coverage for the Sea Ice Atlas. This has changed the backend data from using this: https://nsidc.org/data/nsidc-0051/versions/2#anchor-data-access-tools which is no longer being maintained, to this dataset: https://nsidc.org/data/g02202/versions/6

This is a more or less a drop in replacement for the previous dataset and after the changes to the script, the new files ingest alongside the previous years' GeoTIFFs. 

Make note of the change to how we are identifying the land and no data values as the previous dataset used values above 100 to indicate those values in the grid, while this new dataset requires a different variable which contains a mask of the grid indicating which points are valid sea ice, land, or no data.

**Running this PR**
To run this PR, you will want to go to Zeus and login as the snapdata user. Clone this repository on this branch into /opt/rasdaman/user_data/snapdata and run:
`conda activate hsia_updates`

Then you can run:
`python prefect/hsia/generate_annual_hsia_rasdaman_data.py`

On our production Prefect server, you can run this script with the default parameters to get the new 2025 sea ice concentration GeoTIFFs alongside the rest of the years in: /opt/rasdaman/user_data/snapdata/hsia_updates/rasdaman_hsia_arctic_production_tifs/ and this will also update the production tar ball that contains all of the previous years.