### PR TITLE
Create snapshot of Alaska Wildfires layers

### DIFF
--- a/wildfire_snapshot/create_snapshot.py
+++ b/wildfire_snapshot/create_snapshot.py
@@ -2,10 +2,11 @@ from prefect import flow
 from prefect.blocks.system import Secret
 from snapshot_tasks import create_tarball, upload_to_s3, cleanup_temp_file
 from datetime import datetime
+import os
 
 
 @flow(log_prints=True)
-def create_directory_snapshot(
+def create_alaskawildfires_snapshot(
     source_directory,
     s3_bucket,
 ):
@@ -29,7 +30,12 @@ def create_directory_snapshot(
         aws_access_key_id = Secret.load("alaskawildfires-snapshot-access-key").get()
         aws_secret_access_key = Secret.load("alaskawildfires-snapshot-secret-key").get()
 
-        tarball_path = create_tarball(source_directory, f"{source_directory}.tgz")
+        dir_name = os.path.basename(source_directory)
+        parent_dir = os.path.dirname(source_directory)
+        date_str = datetime.now().strftime("%m_%d_%Y")
+        output_path = os.path.join(parent_dir, f"{dir_name}_{date_str}.tgz")
+
+        tarball_path = create_tarball(source_directory, output_path)
         status["tarball_path"] = tarball_path
 
         s3_uri = upload_to_s3(
@@ -58,7 +64,7 @@ def create_directory_snapshot(
 
 
 if __name__ == "__main__":
-    create_directory_snapshot.serve(
+    create_alaskawildfires_snapshot.serve(
         name="Create Alaska Wildfires Snapshot",
         tags=["wildfire snapshot", "backup"],
         parameters={

--- a/wildfire_snapshot/create_snapshot.py
+++ b/wildfire_snapshot/create_snapshot.py
@@ -1,0 +1,68 @@
+from prefect import flow
+from prefect.blocks.system import Secret
+from snapshot_tasks import create_tarball, upload_to_s3, cleanup_temp_file
+from datetime import datetime
+
+
+@flow(log_prints=True)
+def create_directory_snapshot(
+    source_directory,
+    s3_bucket,
+):
+    """
+    Create a gzipped tarball of a directory and upload it to S3.
+
+    Args:
+        source_directory: Path to the directory to archive
+        s3_bucket: Name of the S3 bucket to upload to
+
+    Returns:
+        Status dictionary with operation details
+    """
+    status = {
+        "started": datetime.now().strftime("%Y%m%d%H%M%S"),
+        "source_directory": source_directory,
+        "s3_bucket": s3_bucket,
+    }
+
+    try:
+        aws_access_key_id = Secret.load("alaskawildfires-snapshot-access-key").get()
+        aws_secret_access_key = Secret.load("alaskawildfires-snapshot-secret-key").get()
+
+        tarball_path = create_tarball(source_directory, f"{source_directory}.tgz")
+        status["tarball_path"] = tarball_path
+
+        s3_uri = upload_to_s3(
+            tarball_path,
+            s3_bucket,
+            aws_access_key_id,
+            aws_secret_access_key,
+        )
+        status["s3_uri"] = s3_uri
+
+        cleanup_temp_file(tarball_path)
+
+        status["completed"] = datetime.now().strftime("%Y%m%d%H%M%S")
+        status["succeeded"] = True
+
+        print("Snapshot creation completed successfully")
+        print(status)
+
+    except Exception as e:
+        status["completed"] = datetime.now().strftime("%Y%m%d%H%M%S")
+        status["succeeded"] = False
+        status["error"] = str(e)
+        print(f"Snapshot creation failed: {e}")
+
+    return status
+
+
+if __name__ == "__main__":
+    create_directory_snapshot.serve(
+        name="Create Directory Snapshot",
+        tags=["wildfire snapshot", "backup"],
+        parameters={
+            "source_directory": "/usr/share/geoserver/data_dir/data/alaska_wildfires",
+            "s3_bucket": "alaskawildfires-snapshots",
+        },
+    )

--- a/wildfire_snapshot/create_snapshot.py
+++ b/wildfire_snapshot/create_snapshot.py
@@ -59,7 +59,7 @@ def create_directory_snapshot(
 
 if __name__ == "__main__":
     create_directory_snapshot.serve(
-        name="Create Directory Snapshot",
+        name="Create Alaska Wildfires Snapshot",
         tags=["wildfire snapshot", "backup"],
         parameters={
             "source_directory": "/usr/share/geoserver/data_dir/data/alaska_wildfires",

--- a/wildfire_snapshot/snapshot_tasks.py
+++ b/wildfire_snapshot/snapshot_tasks.py
@@ -1,0 +1,104 @@
+import os
+import tarfile
+import boto3
+from pathlib import Path
+from prefect import task
+
+
+@task
+def create_tarball(source_directory, output_path=None):
+    """
+    Create a gzipped tarball from a directory.
+
+    Args:
+        source_directory: Path to the directory to archive
+        output_path: Optional path for the output tarball. If None, creates it in /tmp
+
+    Returns:
+        Path to the created tarball
+    """
+    source_path = Path(source_directory)
+
+    if not source_path.exists():
+        raise FileNotFoundError(f"Source directory does not exist: {source_directory}")
+
+    if not source_path.is_dir():
+        raise NotADirectoryError(f"Source path is not a directory: {source_directory}")
+
+    if output_path is None:
+        tarball_name = f"{source_path.name}.tar.gz"
+        output_path = Path("/tmp") / tarball_name
+    else:
+        output_path = Path(output_path)
+
+    print(f"Creating tarball from {source_directory}")
+    print(f"Output path: {output_path}")
+
+    with tarfile.open(output_path, "w:gz") as tar:
+        tar.add(source_directory, arcname=source_path.name)
+
+    tarball_size_mb = output_path.stat().st_size / (1024 * 1024)
+    print(f"Tarball created successfully: {output_path} ({tarball_size_mb:.2f} MB)")
+
+    return str(output_path)
+
+
+@task
+def upload_to_s3(
+    file_path,
+    bucket_name,
+    aws_access_key_id=None,
+    aws_secret_access_key=None,
+):
+    """
+    Upload a file to an S3 bucket.
+
+    Args:
+        file_path: Path to the file to upload
+        bucket_name: Name of the S3 bucket
+        aws_access_key_id: AWS access key (optional if using environment variables or IAM roles)
+        aws_secret_access_key: AWS secret access key (optional if using environment variables or IAM roles)
+
+    Returns:
+        S3 URI of the uploaded file
+    """
+    file_path = Path(file_path)
+
+    if not file_path.exists():
+        raise FileNotFoundError(f"File does not exist: {file_path}")
+
+    print(f"Uploading {file_path} to s3://{bucket_name}/{file_path.name}")
+
+    if aws_access_key_id and aws_secret_access_key:
+        session = boto3.Session(
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+        )
+        s3 = session.client("s3")
+    else:
+        s3 = boto3.client("s3")
+
+    s3.upload_file(str(file_path), bucket_name, file_path.name)
+
+    s3_uri = f"s3://{bucket_name}/{file_path.name}"
+    print(f"Upload complete: {s3_uri}")
+
+    return s3_uri
+
+
+@task
+def cleanup_temp_file(file_path):
+    """
+    Remove a temporary file.
+
+    Args:
+        file_path: Path to the file to remove
+    """
+    file_path = Path(file_path)
+
+    if file_path.exists():
+        print(f"Cleaning up temporary file: {file_path}")
+        file_path.unlink()
+        print("Cleanup complete")
+    else:
+        print(f"File not found, skipping cleanup: {file_path}")


### PR DESCRIPTION
This PR is for a new Prefect workflow that creates a gzipped tarball of the directory containing all of the data that is used by the alaskawildfires.org website inside of Geoserver. This allows for us to return to this point in time by updating the files on a development Geoserver instance if we ever need to show off the Alaska Wildfire Explorer during offseason.

The tarball is uploaded to a S3 bucket called alaskawildfires-snapshots and the tarball is deleted locally as the last step of the workflow.

For testing, go to the production Prefect server and use the deployment "Create Alaska Wildfires Snapshot" and you can run this flow by using a quick run with the default parameters. You will see a new tarball is added to the S3 bucket after the flow finishes running.