### PR TITLE
add CMIP6 FWI ingest

### DIFF
--- a/rasdaman/cmip6_fwi.py
+++ b/rasdaman/cmip6_fwi.py
@@ -1,0 +1,35 @@
+from prefect import flow
+import os
+import ingest_tasks
+
+
+@flow(log_prints=True)
+def cmip6_fwi(
+    branch_name="cmip6_fwi_test",
+    working_directory="/opt/rasdaman/user_data/snapdata/",
+    ingest_directory="/opt/rasdaman/user_data/snapdata/rasdaman-ingest/ardac/cmip6_fwi",
+):
+    ingest_tasks.clone_github_repository(branch_name, working_directory)
+
+    # this function will ingest all the CMIP fire weather JSON files in the ingest directory
+
+    ingest_files = [
+        f
+        for f in os.listdir(ingest_directory)
+        if os.path.isfile(os.path.join(ingest_directory, f)) and f.endswith(".json")
+    ]
+
+    for ingest_file in ingest_files:
+        ingest_tasks.run_ingest(ingest_directory, ingest_file)
+
+
+if __name__ == "__main__":
+    cmip6_fwi.serve(
+        name="Rasdaman Coverages: cmip6_dc, cmip6_dmc, cmip6_ffmc, cmip6_bui, cmip6_fwi, cmip6_isi",
+        tags=["CMIP6", "CFFDRS", "Fire Weather Index"],
+        parameters={
+            "branch_name": "cmip6_fwi_test",
+            "working_directory": "/opt/rasdaman/user_data/snapdata/",
+            "ingest_directory": "/opt/rasdaman/user_data/snapdata/rasdaman-ingest/ardac/cmip6_fwi",
+        },
+    )


### PR DESCRIPTION
This PR adds the ingestion flow for the CMIP6 Fire Weather (FWI) data. To test, log into Zeus as the `snapdata` user, check out this branch of the prefect repo, and review `rasdaman/cmip6_fwi.py`. You will see that the code calls the `cmip6_fwi_test` branch of the `rasdaman-ingest` repo: this is a throwaway testing branch where the coverage names differ from `main` (they have a "_test" suffix) but there are no other differences. 

Start the `cmip6_fwi.py` flow using ```python rasdaman/cmip6_fwi.py``` and run it with the default parameters. The flow should ingest 6 coverages, each taking ~30 minutes. Confirm that each coverage gets fully ingested into Rasdaman, and then delete the test coverages from Rasdaman.

After testing, let me know and I will delete the existing production coverages from Rasdaman, change the `rasdaman-ingest` branch name in `cmip6_fwi.py` to `main`, and re-run the prefect flow to ingest the production coverages using this process. Once that's completed successfully, I'll merge this prefect branch.